### PR TITLE
when admin first logs in, redirect them to user edit page

### DIFF
--- a/app/controllers/concerns/application_controller/login_logistics.rb
+++ b/app/controllers/concerns/application_controller/login_logistics.rb
@@ -25,9 +25,15 @@ module Concerns::ApplicationController::LoginLogistics
     pref_lang = @user_session.user.pref_lang.to_sym
     I18n.locale = configatron.full_locales.include?(pref_lang) ? pref_lang : I18n.default_locale
 
-    # Redirect.
-    best_mission = @user_session.user.best_mission
-    redirect_back_or_default best_mission ? mission_root_path(mission_name: best_mission.compact_name) : basic_root_path
+    # Redirect admin's first login to password reset.
+    if @user_session.user.admin && @user_session.user.login_count <= 1
+      flash[:success] = t("user.set_admin_password")
+      redirect_to url_for(@user_session.user) + '/edit'
+    else
+      # Redirect to most relevant mission
+      best_mission = @user_session.user.best_mission
+      redirect_back_or_default best_mission ? mission_root_path(mission_name: best_mission.compact_name) : basic_root_path
+    end
   end
 
   # resets the Rails session but preserves the :return_to key

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1570,6 +1570,7 @@ en:
     reset_password_label_choose: "Password Creation"
     reset_password_label_reset: "Reset Password?"
     send_email_instructions: "send email instructions"
+    set_admin_password: "Set your admin password and profile information"
     show_printable_instructions: "show printable instructions"
 
   welcome:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1348,6 +1348,7 @@ fr:
     reset_password_label_choose: "Créer mot de passe"
     reset_password_label_reset: "Réinstalisation de mot de passe?"
     send_email_instructions: "Envoyer les instructions par email"
+    set_admin_password: "Réinstaliser le mot de passe et le profil de administrateur"
     show_printable_instructions: "Montrer instructions imprimable"
   welcome:
     awaiting_review: "**%{count}** En attentes de révision"


### PR DESCRIPTION
What's your thought on redirecting on the first login, to make sure that an admin sets up their password and user account? This could be applied to all users. There could be more descriptive text on the page.