### PR TITLE
On first login, redirect admin to their password edit page

### DIFF
--- a/app/controllers/concerns/application_controller/login_logistics.rb
+++ b/app/controllers/concerns/application_controller/login_logistics.rb
@@ -25,9 +25,15 @@ module Concerns::ApplicationController::LoginLogistics
     pref_lang = @user_session.user.pref_lang.to_sym
     I18n.locale = configatron.full_locales.include?(pref_lang) ? pref_lang : I18n.default_locale
 
-    # Redirect.
-    best_mission = @user_session.user.best_mission
-    redirect_back_or_default best_mission ? mission_root_path(mission_name: best_mission.compact_name) : basic_root_path
+    # Redirect admin's first login to password reset.
+    if @user_session.user.admin && @user_session.user.login_count <= 1
+      flash[:success] = t("user.set_admin_password")
+      redirect_to url_for(@user_session.user) + '/edit'
+    else
+      # Redirect to most relevant mission
+      best_mission = @user_session.user.best_mission
+      redirect_back_or_default best_mission ? mission_root_path(mission_name: best_mission.compact_name) : basic_root_path
+    end
   end
 
   # resets the Rails session but preserves the :return_to key

--- a/app/controllers/concerns/application_controller/login_logistics.rb
+++ b/app/controllers/concerns/application_controller/login_logistics.rb
@@ -26,9 +26,9 @@ module Concerns::ApplicationController::LoginLogistics
     I18n.locale = configatron.full_locales.include?(pref_lang) ? pref_lang : I18n.default_locale
 
     # Redirect admin's first login to password reset.
-    if @user_session.user.admin && @user_session.user.login_count <= 1
+    if @user_session.user.admin? && @user_session.user.login_count <= 1
       flash[:success] = t("user.set_admin_password")
-      redirect_to url_for(@user_session.user) + '/edit'
+      redirect_to edit_user_path(@user_session.user)
     else
       # Redirect to most relevant mission
       best_mission = @user_session.user.best_mission

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1595,6 +1595,7 @@ en:
     reset_password_label_choose: "Password Creation"
     reset_password_label_reset: "Reset Password?"
     send_email_instructions: "send email instructions"
+    set_admin_password: "Set your admin password and profile information"
     show_printable_instructions: "show printable instructions"
 
   welcome:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1356,6 +1356,7 @@ fr:
     reset_password_label_choose: "Créer mot de passe"
     reset_password_label_reset: "Réinstalisation de mot de passe?"
     send_email_instructions: "Envoyer les instructions par email"
+    set_admin_password: "Réinstaliser le mot de passe et le profil de administrateur"
     show_printable_instructions: "Montrer instructions imprimable"
   welcome:
     awaiting_review: "**%{count}** En attentes de révision"


### PR DESCRIPTION
Following up #39 with a separate pull request against the develop branch:

When logging in as a newly-created admin user, you are redirected to the profile and password edit page. The user sees a flash message prompting them to enter a new password.