### PR TITLE
2163: Only show admins in dropdown if they are the submitter of a response

### DIFF
--- a/app/controllers/forms_controller.rb
+++ b/app/controllers/forms_controller.rb
@@ -255,7 +255,7 @@ class FormsController < ApplicationController
     # prepares objects and renders the form template
     def prepare_and_render_form
       # render the form template
-      @users = User.assigned_to_or_admin(current_mission).by_name
+      @users = User.assigned_to(current_mission).by_name
       render(:form)
     end
 

--- a/app/controllers/responses_controller.rb
+++ b/app/controllers/responses_controller.rb
@@ -207,9 +207,8 @@ class ResponsesController < ApplicationController
     # prepares objects for and renders the form template
     def prepare_and_render_form
       # get the users to which this response can be assigned
-      # which is the users in this mission plus admins
-      # (we need to include admins because they can submit forms to any mission)
-      @possible_submitters = User.assigned_to_or_admin(current_mission).by_name
+      # which is the users in this mission plus the submitter of this response
+      @possible_submitters = User.assigned_to_or_submitter(current_mission, @response).by_name
 
       # render the form
       render(:form)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -54,6 +54,9 @@ class User < ActiveRecord::Base
   # returns users who are assigned to the given mission OR admins
   scope(:assigned_to_or_admin, ->(m) { where("users.id IN (SELECT user_id FROM assignments WHERE mission_id = ?) OR users.admin = ?", m.try(:id), true) })
 
+  # returns users who are assigned to the given mission OR who submitted the given response
+  scope(:assigned_to_or_submitter, ->(m, r) { where("users.id IN (SELECT user_id FROM assignments WHERE mission_id = ?) OR EXISTS (SELECT 1 FROM responses WHERE id = ? AND user_id = users.id)", m.try(:id), r.try(:id)) })
+
   # we want all of these on one page for now
   self.per_page = 1000000
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -52,7 +52,7 @@ class User < ActiveRecord::Base
   scope(:with_assoc, -> { includes(:missions, {:assignments => :mission}) })
 
   # returns users who are assigned to the given mission OR who submitted the given response
-  scope(:assigned_to_or_submitter, ->(m, r) { where("users.id IN (SELECT user_id FROM assignments WHERE mission_id = ?) OR EXISTS (SELECT 1 FROM responses WHERE id = ? AND user_id = users.id)", m.try(:id), r.try(:id)) })
+  scope(:assigned_to_or_submitter, ->(m, r) { where("users.id IN (SELECT user_id FROM assignments WHERE mission_id = ?) OR users.id = ?", m.try(:id), r.try(:user_id)) })
 
   # we want all of these on one page for now
   self.per_page = 1000000

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -51,9 +51,6 @@ class User < ActiveRecord::Base
   scope(:assigned_to, ->(m) { where("users.id IN (SELECT user_id FROM assignments WHERE mission_id = ?)", m.id) })
   scope(:with_assoc, -> { includes(:missions, {:assignments => :mission}) })
 
-  # returns users who are assigned to the given mission OR admins
-  scope(:assigned_to_or_admin, ->(m) { where("users.id IN (SELECT user_id FROM assignments WHERE mission_id = ?) OR users.admin = ?", m.try(:id), true) })
-
   # returns users who are assigned to the given mission OR who submitted the given response
   scope(:assigned_to_or_submitter, ->(m, r) { where("users.id IN (SELECT user_id FROM assignments WHERE mission_id = ?) OR EXISTS (SELECT 1 FROM responses WHERE id = ? AND user_id = users.id)", m.try(:id), r.try(:id)) })
 

--- a/db/migrate/20150422182449_remove_unassigned_users_from_whitelist.rb
+++ b/db/migrate/20150422182449_remove_unassigned_users_from_whitelist.rb
@@ -1,0 +1,18 @@
+class RemoveUnassignedUsersFromWhitelist < ActiveRecord::Migration
+  def up
+    execute <<-SQL
+      DELETE wl
+      FROM whitelists wl
+        INNER JOIN forms f
+          ON wl.whitelistable_type = 'Form' AND wl.whitelistable_id = f.id
+        INNER JOIN missions m
+          ON f.mission_id = m.id
+      WHERE NOT EXISTS (
+        SELECT 1
+        FROM assignments a
+        WHERE m.id = a.mission_id
+        AND wl.user_id = a.user_id
+      )
+    SQL
+  end
+end


### PR DESCRIPTION
<s>This PR changes the `User.assigned_to_or_admin` scope to only include admins who have submitted a response to a mission.</s>

Let me know if you want me to look at optimizing the queries in this scope; I'd possibly look at using a correlated subquery with `EXISTS`.