### PR TITLE
203: Request throttling for ODK Collect endpoints

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -72,6 +72,9 @@ gem 'ancestry', '~> 2.0'
 
 gem 'rails-backbone', github: 'codebrew/backbone-rails'
 
+# Middleware for handling abusive requests
+gem 'rack-attack'
+
 # XLS support
 gem 'roo'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -198,6 +198,8 @@ GEM
       multi_json (~> 1.0)
       websocket-driver (>= 0.2.0)
     rack (1.6.0)
+    rack-attack (4.2.0)
+      rack
     rack-test (0.6.3)
       rack (>= 1.0)
     rails (4.2.1)
@@ -376,6 +378,7 @@ DEPENDENCIES
   mocha
   mysql2 (>= 0.3.15)
   poltergeist (~> 1.6)
+  rack-attack
   rails (= 4.2.1)
   rails-backbone!
   rails-dev-tweaks (~> 1.1)

--- a/app/controllers/concerns/application_controller/authentication.rb
+++ b/app/controllers/concerns/application_controller/authentication.rb
@@ -28,12 +28,13 @@ module Concerns::ApplicationController::Authentication
       # We use a find call to the User class so that we can do eager loading
       @current_user = User.includes(:assignments).find(user_session.user.id)
 
-    # If the direct_auth or no_auth params are set (usually set in the routes file),
-    # we expect the request to provide its own authentication using e.g. basic auth, or no auth.
-    elsif params[:direct_auth] || params[:no_auth]
+    # If the direct_auth parameter is set (usually set in the routes file), we
+    # expect the request to provide its own authentication using e.g. basic
+    # auth, or no auth.
+    elsif params[:direct_auth]
 
       # Special unauthenticated request.
-      if params[:no_auth]
+      if params[:direct_auth] == 'none'
 
         process_noauth
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -70,5 +70,8 @@ module ELMO
 
     # Do not swallow errors in after_commit/after_rollback callbacks.
     config.active_record.raise_in_transactional_callbacks = true
+
+    # requests-per-minute limit for ODK Collect endpoints
+    configatron.direct_auth_request_limit = 30
   end
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -72,4 +72,7 @@ ELMO::Application.configure do
 
   # Raises error for missing translations
   config.action_view.raise_on_missing_translations = false
+
+  # Enable rack-attack middleware for protecting against brute-force login attempts
+  config.middleware.use Rack::Attack
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -42,5 +42,8 @@ ELMO::Application.configure do
 
   # Sorted order for test cases which are executed.
   config.active_support.test_order = :sorted
+
+  # Use a lower ODK Collect request limit for tests
+  configatron.direct_auth_request_limit = 5
 end
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -45,5 +45,8 @@ ELMO::Application.configure do
 
   # Use a lower ODK Collect request limit for tests
   configatron.direct_auth_request_limit = 5
+
+  # Enable rack-attack middleware for protecting against brute-force login attempts
+  config.middleware.use Rack::Attack
 end
 

--- a/config/initializers/rack-attack.rb
+++ b/config/initializers/rack-attack.rb
@@ -1,13 +1,8 @@
 class Rack::Attack::Request
   def direct_auth?
+    # Match paths starting with "/m/mission_name", but exclude "/m/mission_name/sms" paths
     if path =~ %r{^/m/[a-z][a-z0-9]*/(.*)$}
-      subpath = $1
-
-      return true if subpath == 'formList.xml'
-      return true if subpath =~ %r{^forms/([^/]+)\.xml$}
-      return true if subpath =~ %r{^forms/([^/]+)/manifest\.xml$}
-      return true if subpath =~ %r{^forms/([^/]+)/itemsets\.csv$}
-      return true if subpath == 'submission.xml'
+      return $1 !~ /^sms/
     end
   end
 end

--- a/config/initializers/rack-attack.rb
+++ b/config/initializers/rack-attack.rb
@@ -1,0 +1,20 @@
+class Rack::Attack::Request
+  def direct_auth?
+    if path =~ %r{^/m/[a-z][a-z0-9]*/(.*)$}
+      subpath = $1
+
+      return true if subpath == 'formList.xml'
+      return true if subpath =~ %r{^forms/([^/]+)\.xml$}
+      return true if subpath =~ %r{^forms/([^/]+)/manifest\.xml$}
+      return true if subpath =~ %r{^forms/([^/]+)/itemsets\.csv$}
+      return true if subpath == 'submission.xml'
+    end
+  end
+end
+
+class Rack::Attack
+  # Limit ODK Collect and other :direct_auth requests by IP address to 30 requests per minute
+  throttle('req/ip', limit: 30, period: 1.minute) do |req|
+    req.ip if req.direct_auth?
+  end
+end

--- a/config/initializers/rack-attack.rb
+++ b/config/initializers/rack-attack.rb
@@ -13,8 +13,8 @@ class Rack::Attack::Request
 end
 
 class Rack::Attack
-  # Limit ODK Collect and other :direct_auth requests by IP address to 30 requests per minute
-  throttle('req/ip', limit: 30, period: 1.minute) do |req|
+  # Limit ODK Collect requests by IP address to N requests per minute
+  throttle('req/ip', limit: proc { configatron.direct_auth_request_limit }, period: 1.minute) do |req|
     req.ip if req.direct_auth?
   end
 end

--- a/config/initializers/rack-attack.rb
+++ b/config/initializers/rack-attack.rb
@@ -9,7 +9,7 @@ end
 
 class Rack::Attack
   # Limit ODK Collect requests by IP address to N requests per minute
-  throttle('req/ip', limit: proc { configatron.direct_auth_request_limit }, period: 1.minute) do |req|
+  throttle('direct-auth-req/ip', limit: proc { configatron.direct_auth_request_limit }, period: 1.minute) do |req|
     req.ip if req.direct_auth?
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -125,22 +125,24 @@ ELMO::Application.routes.draw do
     end
   end
 
-  # Special SMS and ODK routes. No locale.
+  # Special SMS routes. No locale.
   scope '/m/:mission_name', mission_name: /[a-z][a-z0-9]*/, defaults: { mode: 'm'} do
     resources :sms, only: [:create]
     get '/sms/submit' => 'sms#create'
+  end
 
-    # ODK routes. They are down here so that forms_path doesn't return the ODK variant.
-    #
-    # NOTE: Brute-force login protection happens in the rack-attack middleware,
-    # which executes before routing. Be sure that all paths marked with
-    # :direct_auth => true are also matched by the direct_auth? method in
-    # config/initializers/rack-attack.rb
-    get '/formList' => 'forms#index', as: :odk_form_list, defaults: {format: 'xml', direct_auth: true}
-    get '/forms/:id' => 'forms#show', as: :odk_form, defaults: {format: 'xml', direct_auth: true}
-    get '/forms/:id/manifest' => 'forms#odk_manifest', as: :odk_form_manifest, defaults: {format: 'xml', direct_auth: true}
-    get '/forms/:id/itemsets' => 'forms#odk_itemsets', as: :odk_form_itemsets, defaults: {format: 'csv', direct_auth: true}
-    match '/submission' => 'responses#create', via: [:get, :head, :post], defaults: {format: 'xml', direct_auth: true}
+  # Special ODK routes. No locale. They are down here so that forms_path doesn't return the ODK variant.
+  #
+  # NOTE: Brute-force login protection happens in the rack-attack middleware,
+  # which executes before routing. Be sure that all paths marked with
+  # :direct_auth => true are also matched by the direct_auth? method in
+  # config/initializers/rack-attack.rb
+  scope '/m/:mission_name', mission_name: /[a-z][a-z0-9]*/, defaults: { mode: 'm', direct_auth: true } do
+    get '/formList' => 'forms#index', as: :odk_form_list, defaults: {format: 'xml'}
+    get '/forms/:id' => 'forms#show', as: :odk_form, defaults: {format: 'xml'}
+    get '/forms/:id/manifest' => 'forms#odk_manifest', as: :odk_form_manifest, defaults: {format: 'xml'}
+    get '/forms/:id/itemsets' => 'forms#odk_itemsets', as: :odk_form_itemsets, defaults: {format: 'csv'}
+    match '/submission' => 'responses#create', via: [:get, :head, :post], defaults: {format: 'xml'}
 
     # Unauthenticated submissions
     match '/noauth/submission' => 'responses#create', via: [:get, :head, :post], defaults: {format: :xml, no_auth: true}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -137,7 +137,7 @@ ELMO::Application.routes.draw do
   # which executes before routing. Be sure that all paths marked with
   # :direct_auth => true are also matched by the direct_auth? method in
   # config/initializers/rack-attack.rb
-  scope '/m/:mission_name', mission_name: /[a-z][a-z0-9]*/, defaults: { mode: 'm', direct_auth: true } do
+  scope '/m/:mission_name', mission_name: /[a-z][a-z0-9]*/, defaults: { mode: 'm', direct_auth: 'basic' } do
     get '/formList' => 'forms#index', as: :odk_form_list, defaults: {format: 'xml'}
     get '/forms/:id' => 'forms#show', as: :odk_form, defaults: {format: 'xml'}
     get '/forms/:id/manifest' => 'forms#odk_manifest', as: :odk_form_manifest, defaults: {format: 'xml'}
@@ -145,7 +145,7 @@ ELMO::Application.routes.draw do
     match '/submission' => 'responses#create', via: [:get, :head, :post], defaults: {format: 'xml'}
 
     # Unauthenticated submissions
-    match '/noauth/submission' => 'responses#create', via: [:get, :head, :post], defaults: {format: :xml, no_auth: true}
+    match '/noauth/submission' => 'responses#create', via: [:get, :head, :post], defaults: {format: :xml, direct_auth: 'none'}
   end
 
   # API routes.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -131,6 +131,11 @@ ELMO::Application.routes.draw do
     get '/sms/submit' => 'sms#create'
 
     # ODK routes. They are down here so that forms_path doesn't return the ODK variant.
+    #
+    # NOTE: Brute-force login protection happens in the rack-attack middleware,
+    # which executes before routing. Be sure that all paths marked with
+    # :direct_auth => true are also matched by the direct_auth? method in
+    # config/initializers/rack-attack.rb
     get '/formList' => 'forms#index', as: :odk_form_list, defaults: {format: 'xml', direct_auth: true}
     get '/forms/:id' => 'forms#show', as: :odk_form, defaults: {format: 'xml', direct_auth: true}
     get '/forms/:id/manifest' => 'forms#odk_manifest', as: :odk_form_manifest, defaults: {format: 'xml', direct_auth: true}

--- a/spec/requests/request_throttling_spec.rb
+++ b/spec/requests/request_throttling_spec.rb
@@ -1,0 +1,42 @@
+require 'spec_helper'
+
+describe 'throttling for xml requests' do
+
+  let(:limit) { 30 }
+
+  before(:each) do
+    Rack::Attack.cache.store = ActiveSupport::Cache::MemoryStore.new
+  end
+
+  context 'with the same ip address' do
+    it 'should not apply to requests below the limit' do
+      limit.times do
+        get "/m/#{get_mission.compact_name}/formList.xml"
+        assert_response :unauthorized
+      end
+    end
+
+    it 'should apply to requests above the limit with response code 429' do
+      (limit + 1).times do |i|
+        get "/m/#{get_mission.compact_name}/formList.xml"
+        if i < limit
+          assert_response :unauthorized
+        else
+          assert_response :too_many_requests
+        end
+      end
+    end
+  end
+
+  context 'with different ip addresses' do
+    let(:remote_addrs) { ['1.1.1.1', '2.2.2.2', '3.3.3.3'] * limit }
+
+    it 'should not apply' do
+      (limit * 2).times do |i|
+        get "/m/#{get_mission.compact_name}/formList.xml", nil, { REMOTE_ADDR: remote_addrs[i] }
+        assert_response :unauthorized
+      end
+    end
+  end
+
+end

--- a/spec/requests/request_throttling_spec.rb
+++ b/spec/requests/request_throttling_spec.rb
@@ -54,4 +54,13 @@ describe 'throttling for xml requests' do
     end
   end
 
+  context 'for sms requests under /m/mission_name' do
+    it 'should not apply' do
+      (limit + 1).times do |i|
+        post "/m/#{get_mission.compact_name}/sms?from=14045551212&text=test&msgid=123&sent=2015-04-27T10:53:00-700"
+        assert_response :ok
+      end
+    end
+  end
+
 end

--- a/spec/requests/request_throttling_spec.rb
+++ b/spec/requests/request_throttling_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe 'throttling for xml requests' do
 
-  let(:limit) { 30 }
+  let(:limit) { configatron.direct_auth_request_limit }
 
   before(:each) do
     Rack::Attack.cache.store = ActiveSupport::Cache::MemoryStore.new

--- a/spec/requests/request_throttling_spec.rb
+++ b/spec/requests/request_throttling_spec.rb
@@ -11,14 +11,14 @@ describe 'throttling for xml requests' do
   context 'with the same ip address' do
     it 'should not apply to requests below the limit' do
       limit.times do
-        get "/m/#{get_mission.compact_name}/formList.xml"
+        get "/m/#{get_mission.compact_name}/formList"
         assert_response :unauthorized
       end
     end
 
     it 'should apply to requests above the limit with response code 429' do
       (limit + 1).times do |i|
-        get "/m/#{get_mission.compact_name}/formList.xml"
+        get "/m/#{get_mission.compact_name}/formList"
         if i < limit
           assert_response :unauthorized
         else
@@ -33,7 +33,7 @@ describe 'throttling for xml requests' do
 
     it 'should not apply' do
       (limit * 2).times do |i|
-        get "/m/#{get_mission.compact_name}/formList.xml", nil, { REMOTE_ADDR: remote_addrs[i] }
+        get "/m/#{get_mission.compact_name}/formList", nil, { REMOTE_ADDR: remote_addrs[i] }
         assert_response :unauthorized
       end
     end


### PR DESCRIPTION
This PR implements the request throttling portion of issue 203 for the ODK Collect endpoints.

I haven't yet made it configurable, but that would involve using a `proc` for `:limit` (to ensure that the config has been fully loaded). Let me know if you actually want this to be configurable.

I also added a spec.

One thing I wasn't sure about was whether to make `direct_auth?` match paths without `.xml`. There are tests in `basic_authentication_spec.rb` that aren't using `.xml`, so I'm not sure what's actually being requested by ODK Collect. I also recall @hooverlunch mentioning that there is a potentially conflicting path for `/forms/:id`.