### PR TITLE
203: Require reCAPTCHA on excessive login attempts

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -77,6 +77,9 @@ gem 'rails-backbone', github: 'codebrew/backbone-rails'
 # Middleware for handling abusive requests
 gem 'rack-attack'
 
+# reCAPTCHA support
+gem "recaptcha", :require => "recaptcha/rails"
+
 # XLS support
 gem 'roo'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -237,6 +237,7 @@ GEM
     rake (10.4.2)
     random_data (1.6.0)
     rdiscount (2.1.8)
+    recaptcha (0.4.0)
     ref (1.0.5)
     request_store (1.1.0)
     responders (2.1.0)
@@ -385,11 +386,9 @@ DEPENDENCIES
   rake
   random_data
   rdiscount
-<<<<<<< HEAD
+  recaptcha
   responders (~> 2.0)
-=======
   reverse_markdown
->>>>>>> 453764e... 2235: Fixed CSV long text formatting.
   roo
   rspec-rails (~> 3.0)
   sass-rails (~> 4.0.2)

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -50,6 +50,7 @@ class UserSessionsController < ApplicationController
 
     def allow_login
       if captcha_required?
+        Rails.logger.info "Verifying reCAPTCHA submission for #{request.remote_ip}"
         verify_recaptcha(model: @user_session)
       else
         true

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -50,7 +50,7 @@ class UserSessionsController < ApplicationController
 
     def allow_login
       if captcha_required?
-        verify_recaptcha(model: @user_session, attribute: :verify_login)
+        verify_recaptcha(model: @user_session)
       else
         true
       end

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -18,7 +18,7 @@ class UserSessionsController < ApplicationController
     @user_session = UserSession.new(params[:user_session])
 
     # if the save is successful, the user is logged in automatically
-    if check_captcha && @user_session.save
+    if allow_login && @user_session.save
       post_login_housekeeping
     else
       flash[:error] = @user_session.errors.full_messages.join(",")
@@ -48,11 +48,15 @@ class UserSessionsController < ApplicationController
 
   private
 
-    def check_captcha
-      captcha_required? && verify_recaptcha(model: @user_session, attribute: :verify_login)
+    def allow_login
+      if captcha_required?
+        verify_recaptcha(model: @user_session, attribute: :verify_login)
+      else
+        true
+      end
     end
 
     def captcha_required?
-      Recaptcha.configuration.public_key.present?
+      !!request.env['elmo.captcha_required']
     end
 end

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -1,5 +1,7 @@
 class UserSessionsController < ApplicationController
 
+  helper_method :captcha_required?
+
   # don't need to authorize here (except for destroy action) because anyone can see log in page
   skip_authorization_check
 
@@ -16,7 +18,7 @@ class UserSessionsController < ApplicationController
     @user_session = UserSession.new(params[:user_session])
 
     # if the save is successful, the user is logged in automatically
-    if @user_session.save
+    if check_captcha && @user_session.save
       post_login_housekeeping
     else
       flash[:error] = @user_session.errors.full_messages.join(",")
@@ -43,4 +45,14 @@ class UserSessionsController < ApplicationController
     # We redirect to user profile instead of dashboard because dashboard is slower to load and is not needed.
     redirect_to user_path(@user, locale: 'en', mode: 'm', mission_name: @user.best_mission.compact_name)
   end
+
+  private
+
+    def check_captcha
+      captcha_required? && verify_recaptcha(model: @user_session, attribute: :verify_login)
+    end
+
+    def captcha_required?
+      Recaptcha.configuration.public_key.present?
+    end
 end

--- a/app/helpers/captcha_helper.rb
+++ b/app/helpers/captcha_helper.rb
@@ -1,5 +1,0 @@
-module CaptchaHelper
-  def captcha_enabled?
-    Recaptcha.configuration.public_key.present?
-  end
-end

--- a/app/helpers/captcha_helper.rb
+++ b/app/helpers/captcha_helper.rb
@@ -1,0 +1,5 @@
+module CaptchaHelper
+  def captcha_enabled?
+    Recaptcha.configuration.public_key.present?
+  end
+end

--- a/app/views/user_sessions/new.html.erb
+++ b/app/views/user_sessions/new.html.erb
@@ -1,6 +1,7 @@
 <%= elmo_form_for(@user_session, :url => user_session_path, :style => :minimal) do |f| %>
   <%= f.field(:login) %>
   <%= f.field(:password, :type => :password) %>
+  <%= f.field(:captcha, :content => recaptcha_tags) if captcha_enabled? %>
   <div class="submit-buttons">
     <%= f.submit(:login, :class => "btn btn-primary") %><br/><br/>
     <%= link_to(t("user.forgot_password"), new_password_reset_path) %>

--- a/app/views/user_sessions/new.html.erb
+++ b/app/views/user_sessions/new.html.erb
@@ -1,7 +1,7 @@
 <%= elmo_form_for(@user_session, :url => user_session_path, :style => :minimal) do |f| %>
   <%= f.field(:login) %>
   <%= f.field(:password, :type => :password) %>
-  <%= f.field(:verify_login, :content => recaptcha_tags) if captcha_required? %>
+  <%= f.field(:verify, :content => recaptcha_tags) if captcha_required? %>
   <div class="submit-buttons">
     <%= f.submit(:login, :class => "btn btn-primary") %><br/><br/>
     <%= link_to(t("user.forgot_password"), new_password_reset_path) %>

--- a/app/views/user_sessions/new.html.erb
+++ b/app/views/user_sessions/new.html.erb
@@ -1,7 +1,7 @@
 <%= elmo_form_for(@user_session, :url => user_session_path, :style => :minimal) do |f| %>
   <%= f.field(:login) %>
   <%= f.field(:password, :type => :password) %>
-  <%= f.field(:captcha, :content => recaptcha_tags) if captcha_enabled? %>
+  <%= f.field(:verify_login, :content => recaptcha_tags) if captcha_required? %>
   <div class="submit-buttons">
     <%= f.submit(:login, :class => "btn btn-primary") %><br/><br/>
     <%= link_to(t("user.forgot_password"), new_password_reset_path) %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -73,5 +73,8 @@ module ELMO
 
     # requests-per-minute limit for ODK Collect endpoints
     configatron.direct_auth_request_limit = 30
+
+    # logins-per-minute threshold for showing a captcha
+    configatron.login_captcha_threshold = 30
   end
 end

--- a/config/initializers/local_config.rb.example
+++ b/config/initializers/local_config.rb.example
@@ -36,3 +36,10 @@ configatron.allow_unauthenticated_submissions = false
 
 # generate your secret key with `rake secret`
 ELMO::Application.config.secret_key_base = 'secret-token'
+
+# Configure reCAPTCHA for brute-force login protection
+# Keys may be obtained from https://www.google.com/recaptcha/admin
+Recaptcha.configure do |config|
+  config.public_key = nil  # '6LdN_QUTAAAAAN_oha......................'
+  config.private_key = nil # '6LdN_QUTAAAAAOaPvp......................'
+end

--- a/config/initializers/rack-attack.rb
+++ b/config/initializers/rack-attack.rb
@@ -5,11 +5,32 @@ class Rack::Attack::Request
       return $1 !~ /^sms/
     end
   end
+
+  def login_related?
+    path =~ %r{/user-session\b} or path =~ %r{/login\b}
+  end
+
+  def login_attempts_exceeded?
+    env['rack.attack.matched'] == 'login-attempts/ip' && env['rack.attack.match_type'] == :track
+  end
 end
 
-class Rack::Attack
-  # Limit ODK Collect requests by IP address to N requests per minute
-  throttle('direct-auth-req/ip', limit: proc { configatron.direct_auth_request_limit }, period: 1.minute) do |req|
-    req.ip if req.direct_auth?
+# Limit ODK Collect requests by IP address to N requests per minute
+Rack::Attack.throttle('direct-auth-req/ip', limit: proc { configatron.direct_auth_request_limit }, period: 1.minute) do |req|
+  req.ip if req.direct_auth?
+end
+
+if Recaptcha.configuration.public_key.present?
+  # Track rate of attempted logins by IP address per minute to allow reCAPTCHA display
+  Rack::Attack.track('login-attempts/ip', limit: proc { configatron.login_captcha_threshold }, period: 1.minute) do |req|
+    req.ip if req.login_related?
+  end
+
+  # Set 'elmo.captcha_required=true' in the Rack env if the rate is exceeded
+  ActiveSupport::Notifications.subscribe('rack.attack') do |_,_,_,_,req|
+    if req.login_attempts_exceeded?
+      Rails.logger.info "Login attempts per minute exceeded; enabling reCAPTCHA"
+      req.env['elmo.captcha_required'] = true
+    end
   end
 end

--- a/config/initializers/rack-attack.rb
+++ b/config/initializers/rack-attack.rb
@@ -22,7 +22,8 @@ end
 
 if Recaptcha.configuration.public_key.present?
   # Track rate of attempted logins by IP address per minute to allow reCAPTCHA display
-  Rack::Attack.track('login-attempts/ip', limit: proc { configatron.login_captcha_threshold }, period: 1.minute) do |req|
+  # We use double the amount specified by login_captcha_threshold to account for the GET/POST cycle of a failed login attempt 
+  Rack::Attack.track('login-attempts/ip', limit: proc { 2 * configatron.login_captcha_threshold }, period: 1.minute) do |req|
     req.ip if req.login_related?
   end
 

--- a/config/initializers/rack-attack.rb
+++ b/config/initializers/rack-attack.rb
@@ -29,7 +29,7 @@ end
 # Set 'elmo.captcha_required=true' in the Rack env if the rate is exceeded
 ActiveSupport::Notifications.subscribe('rack.attack') do |_,_,_,_,req|
   if req.login_attempts_exceeded?
-    Rails.logger.info "Login attempts per minute exceeded; enabling reCAPTCHA"
+    Rails.logger.info "Login attempts per minute exceeded; enabling reCAPTCHA for #{req.ip}"
     req.env['elmo.captcha_required'] = true
   end
 end

--- a/config/initializers/recaptcha.rb
+++ b/config/initializers/recaptcha.rb
@@ -3,3 +3,12 @@
 Recaptcha.configure do |config|
   config.api_version = 'v2'
 end
+
+# Ensure that the reCAPTCHA keys have been set after all initializers finish
+ELMO::Application.config.after_initialize do
+  Recaptcha.configuration.tap do |config|
+    unless config.public_key.present? && config.private_key.present?
+      raise "Missing reCAPTCHA keys. See local_config.rb.example for configuration guidance."
+    end
+  end
+end

--- a/config/initializers/recaptcha.rb
+++ b/config/initializers/recaptcha.rb
@@ -1,0 +1,5 @@
+# Recaptcha public and private keys should be set with the RECAPTCHA_PUBLIC_KEY
+# and RECAPTCHA_PRIVATE_KEY environment variables, or in local_config.rb
+Recaptcha.configure do |config|
+  config.api_version = 'v2'
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -738,6 +738,7 @@ en:
         login: "Username"
         password: "Password"
         remember_me: "Remember Me"
+        verify: "Verify"
 
   # time/date formats (see http://www.ruby-doc.org/core-2.0/Time.html#method-i-strftime for code meanings)
   date:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1082,6 +1082,11 @@ en:
     date: "Date"
     time: "Time"
 
+  recaptcha:
+    errors:
+      verification_failed: "Verification response is incorrect, please try again."
+      recaptcha_unreachable: "Oops, we failed to validate your verification response. Please try again."
+
   report/report:
     add_column: "Add Column"
     answered_only_if: "Answered only if"


### PR DESCRIPTION
This PR enables support for requiring a reCAPTCHA when an excessive number of login attempts are made.

In the current implementation, both `GET` requests to `/xx/login` and all requests to `/xx/user-session/**` will count toward the threshold. Doing otherwise would require some sort of explicit check against the `rack-attack` tracking data stored in `Rack::Attack.cache`.

This will also need to be localized, particularly the `:verify_login` label on the login page and the reCAPTCHA itself (achievable with the `hl` parameter to `recaptcha_tags`).