### PR TITLE
2215: Implemented delayed delta indexing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -61,6 +61,7 @@ gem 'ejs'
 gem 'thinking-sphinx', '~> 3.1.3'
 
 # search: delayed deltas
+gem 'daemons'
 gem 'delayed_job_active_record'
 gem 'ts-delayed-delta', '~> 2.0.2'
 

--- a/Gemfile
+++ b/Gemfile
@@ -59,6 +59,9 @@ gem 'ejs'
 
 # search
 gem 'thinking-sphinx', '~> 3.1.3'
+
+# search: delayed deltas
+gem 'delayed_job_active_record'
 gem 'ts-delayed-delta', '~> 2.0.2'
 
 # cron management

--- a/Gemfile
+++ b/Gemfile
@@ -59,6 +59,7 @@ gem 'ejs'
 
 # search
 gem 'thinking-sphinx', '~> 3.1.3'
+gem 'ts-delayed-delta', '~> 2.0.2'
 
 # cron management
 gem 'whenever', :require => false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -132,6 +132,8 @@ GEM
     daemons (1.2.1)
     dalli (2.7.4)
     database_cleaner (1.4.1)
+    delayed_job (4.0.6)
+      activesupport (>= 3.0, < 5.0)
     descriptive_statistics (2.5.1)
     diff-lcs (1.2.5)
     ejs (1.1.1)
@@ -324,6 +326,9 @@ GEM
     tilt (1.4.1)
     timecop (0.7.3)
     tins (1.3.5)
+    ts-delayed-delta (2.0.2)
+      delayed_job
+      thinking-sphinx (>= 1.5.0)
     twilio-ruby (4.1.0)
       builder (>= 2.1.2)
       jwt (~> 1.0)
@@ -411,6 +416,7 @@ DEPENDENCIES
   thin
   thinking-sphinx (~> 3.1.3)
   timecop
+  ts-delayed-delta (~> 2.0.2)
   twilio-ruby (~> 4.1)
   uglifier (>= 1.3.0)
   versionist

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -134,6 +134,9 @@ GEM
     database_cleaner (1.4.1)
     delayed_job (4.0.6)
       activesupport (>= 3.0, < 5.0)
+    delayed_job_active_record (4.0.3)
+      activerecord (>= 3.0, < 5.0)
+      delayed_job (>= 3.0, < 4.1)
     descriptive_statistics (2.5.1)
     diff-lcs (1.2.5)
     ejs (1.1.1)
@@ -379,6 +382,7 @@ DEPENDENCIES
   configatron (~> 4.2)
   dalli
   database_cleaner
+  delayed_job_active_record
   descriptive_statistics
   ejs
   factory_girl_rails (~> 4.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -380,6 +380,7 @@ DEPENDENCIES
   capistrano (~> 2.15.4)
   capybara
   configatron (~> 4.2)
+  daemons
   dalli
   database_cleaner
   delayed_job_active_record

--- a/app/indices/answer_index.rb
+++ b/app/indices/answer_index.rb
@@ -1,4 +1,4 @@
-ThinkingSphinx::Index.define :answer, :with => :active_record, :delta => true do
+ThinkingSphinx::Index.define :answer, :with => :active_record, :delta => ThinkingSphinx::Deltas::DelayedDelta do
   # fields
   indexes value
 

--- a/bin/delayed_job
+++ b/bin/delayed_job
@@ -1,0 +1,5 @@
+#!/usr/bin/env ruby
+
+require File.expand_path(File.join(File.dirname(__FILE__), '..', 'config', 'environment'))
+require 'delayed/command'
+Delayed::Command.new(ARGV).daemonize

--- a/config/application.rb
+++ b/config/application.rb
@@ -47,6 +47,9 @@ module ELMO
     # Version of your assets, change this if you want to expire all your assets
     config.assets.version = '1.0'
 
+    # Use Delayed::Job as the ActiveJob queue adapter
+    config.active_job.queue_adapter = :delayed_job
+
     config.generators do |g|
       g.test_framework :rspec
       g.integration_framework :rspec

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -50,6 +50,11 @@ after "deploy", "thinking_sphinx:rebuild"
 
 after "deploy", "deploy:cleanup" # keep only the last 5 releases
 
+# Tie delayed_job lifecycle to the main lifecycle
+after "deploy:stop",    "delayed_job:stop"
+after "deploy:start",   "delayed_job:start"
+after "deploy:restart", "delayed_job:restart"
+
 namespace :deploy do
 
   task :setup_config, roles: :app do

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -19,8 +19,8 @@ set(:whenever_identifier) {"elmo_#{stage}"}
 require "whenever/capistrano"
 
 # delayed_jobs settings
-# NOTE: :delayed_job_role must match :thinking_sphinx_roles, which defaults to :db
-set :delayed_job_role, :db
+# NOTE: :delayed_job_server_role must match :thinking_sphinx_roles, which defaults to :db
+set :delayed_job_server_role, :db
 set :delayed_job_command, 'bundle exec bin/delayed_job'
 require 'delayed/recipes'
 

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -18,6 +18,12 @@ set :whenever_command, "bundle exec whenever"
 set(:whenever_identifier) {"elmo_#{stage}"}
 require "whenever/capistrano"
 
+# delayed_jobs settings
+# NOTE: :delayed_job_role must match :thinking_sphinx_roles, which defaults to :db
+set :delayed_job_role, :db
+set :delayed_job_command, 'bundle exec bin/delayed_job'
+require 'delayed/recipes'
+
 set :application, "elmo"
 set :repository, "https://github.com/thecartercenter/elmo.git"
 set :deploy_via, :remote_cache

--- a/config/deploy/staging.rb
+++ b/config/deploy/staging.rb
@@ -1,5 +1,5 @@
 set :branch, 'staging'
-set :ping_url, "https://secure1.cceom.org"
+set :ping_url, "https://staging.getelmo.org"
 set :user, 'cceom'
 set :home_dir, '/home/cceom'
 set :use_sudo, false

--- a/config/deploy/staging.rb
+++ b/config/deploy/staging.rb
@@ -5,7 +5,7 @@ set :home_dir, '/home/cceom'
 set :use_sudo, false
 set(:deploy_to) {"#{home_dir}/webapps/elmo_rails/#{stage}"}
 set :default_environment, {
-  "PATH" => "$PATH:$HOME/bin:$HOME/webapps/elmo_rails/bin",
+  "PATH" => "$HOME/bin:$HOME/webapps/elmo_rails/bin:$PATH",
   "GEM_HOME" => "$HOME/webapps/elmo_rails/gems"
 }
 

--- a/db/migrate/20150522175056_create_delayed_jobs.rb
+++ b/db/migrate/20150522175056_create_delayed_jobs.rb
@@ -1,0 +1,22 @@
+class CreateDelayedJobs < ActiveRecord::Migration
+  def self.up
+    create_table :delayed_jobs, force: true do |table|
+      table.integer :priority, default: 0, null: false # Allows some jobs to jump to the front of the queue
+      table.integer :attempts, default: 0, null: false # Provides for retries, but still fail eventually.
+      table.text :handler,                 null: false # YAML-encoded string of the object that will do work
+      table.text :last_error                           # reason for last failure (See Note below)
+      table.datetime :run_at                           # When to run. Could be Time.zone.now for immediately, or sometime in the future.
+      table.datetime :locked_at                        # Set when a client is working on this object
+      table.datetime :failed_at                        # Set when all retries have failed (actually, by default, the record is deleted instead)
+      table.string :locked_by                          # Who is working on this object (if locked)
+      table.string :queue                              # The name of the queue this job is in
+      table.timestamps null: true
+    end
+
+    add_index :delayed_jobs, [:priority, :run_at], name: "delayed_jobs_priority"
+  end
+
+  def self.down
+    drop_table :delayed_jobs
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150518221437) do
+ActiveRecord::Schema.define(version: 20150522175056) do
 
   create_table "answers", force: :cascade do |t|
     t.integer  "response_id",    limit: 4
@@ -89,6 +89,22 @@ ActiveRecord::Schema.define(version: 20150518221437) do
   add_index "conditions", ["mission_id"], name: "index_conditions_on_mission_id", using: :btree
   add_index "conditions", ["questioning_id"], name: "conditions_questioning_id_fk", using: :btree
   add_index "conditions", ["ref_qing_id"], name: "conditions_ref_qing_id_fk", using: :btree
+
+  create_table "delayed_jobs", force: :cascade do |t|
+    t.integer  "priority",   limit: 4,     default: 0, null: false
+    t.integer  "attempts",   limit: 4,     default: 0, null: false
+    t.text     "handler",    limit: 65535,             null: false
+    t.text     "last_error", limit: 65535
+    t.datetime "run_at"
+    t.datetime "locked_at"
+    t.datetime "failed_at"
+    t.string   "locked_by",  limit: 255
+    t.string   "queue",      limit: 255
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  add_index "delayed_jobs", ["priority", "run_at"], name: "delayed_jobs_priority", using: :btree
 
   create_table "form_items", force: :cascade do |t|
     t.integer  "question_id",             limit: 4

--- a/docs/production-setup.md
+++ b/docs/production-setup.md
@@ -107,6 +107,8 @@ Enter sensible values for the settings in the file. Entering a functioning email
     bundle exec rake assets:precompile
     # Build search indices
     bundle exec rake ts:rebuild
+    # Start background job processor
+    bundle exec bin/delayed_job start
     # Restart server
     sudo service nginx restart
 
@@ -132,6 +134,7 @@ When new versions of ELMO are released, you will want to upgrade. To do so, ssh 
     bundle exec rake db:migrate
     bundle exec rake assets:precompile
     bundle exec rake ts:rebuild
+    bundle exec bin/delayed_job restart
     touch tmp/restart.txt
 
 Then load the site in your browser. You should see the new version number in the page footer.


### PR DESCRIPTION
This PR adds the [`ts-delayed-delta`](https://github.com/pat/ts-delayed-delta/) gem to allow Thinking Sphinx deltas to be processed via `delayed_job`.

I've also updated the Capistrano scripts to fix a couple bugs in `staging.rb` as well as to start DJ along with the main Nginx process.