### PR TITLE
2215: Limit delayed job delta indexing to RAILS_ENV=production

### DIFF
--- a/app/indices/answer_index.rb
+++ b/app/indices/answer_index.rb
@@ -1,4 +1,6 @@
-ThinkingSphinx::Index.define :answer, :with => :active_record, :delta => ThinkingSphinx::Deltas::DelayedDelta do
+delta = Rails.env.production? ? ThinkingSphinx::Deltas::DelayedDelta : true
+
+ThinkingSphinx::Index.define :answer, :with => :active_record, :delta => delta do
   # fields
   indexes value
 


### PR DESCRIPTION
Forgot to include this change in #67 