### PR TITLE
892: Scalable user selection

### DIFF
--- a/app/assets/javascripts/response.js
+++ b/app/assets/javascripts/response.js
@@ -11,6 +11,9 @@
 
     // initialize conditions
     $.each(klass.conditions, function(i, cond){ cond.init(); });
+
+    // enable select2 for user selector
+    $('#response_user_id').select2();
   }
 
   // shows the map and location search box

--- a/app/assets/javascripts/response.js
+++ b/app/assets/javascripts/response.js
@@ -5,7 +5,7 @@
   // conditions array
   klass.conditions = [];
 
-  klass.init = function() {
+  klass.init = function(options) {
     // hookup edit location links
     $("a.edit_location_link").click(function(e){ klass.show_location_picker(e); return false; });
 
@@ -13,7 +13,25 @@
     $.each(klass.conditions, function(i, cond){ cond.init(); });
 
     // enable select2 for user selector
-    $('#response_user_id').select2();
+    $('#response_user_id').select2({
+      ajax: {
+        url: options.url,
+        dataType: 'json',
+        delay: 250,
+        data: function (params) {
+          return {
+            search: params.term,
+            page: params.page
+          };
+        },
+        processResults: function (data, page) {
+          var results = _.map(data, function (i) { i.text = i.name; return i; });
+          return { results: results };
+        },
+        cache: true
+      },
+      minimumInputLength: 1
+    });
   }
 
   // shows the map and location search box

--- a/app/assets/javascripts/response.js
+++ b/app/assets/javascripts/response.js
@@ -25,8 +25,11 @@
           };
         },
         processResults: function (data, page) {
-          var results = _.map(data, function (i) { i.text = i.name; return i; });
-          return { results: results };
+          var results = _.map(data.possible_submitters, function (i) { i.text = i.name; return i; });
+          return {
+            results: results,
+            pagination: { more: data.more }
+          };
         },
         cache: true
       },

--- a/app/assets/javascripts/response.js
+++ b/app/assets/javascripts/response.js
@@ -32,8 +32,7 @@
           };
         },
         cache: true
-      },
-      minimumInputLength: 1
+      }
     });
   }
 

--- a/app/controllers/responses_controller.rb
+++ b/app/controllers/responses_controller.rb
@@ -187,7 +187,10 @@ class ResponsesController < ApplicationController
 
     @possible_submitters = @possible_submitters.paginate(:page => params[:page], :per_page => 20)
 
-    render json: @possible_submitters.to_json(:include_id => true)
+    render :json => {
+      :possible_submitters => @possible_submitters.as_json(:only => %i(id name)),
+      :more => @possible_submitters.next_page.present?
+    }
   end
 
   private

--- a/app/controllers/responses_controller.rb
+++ b/app/controllers/responses_controller.rb
@@ -170,6 +170,26 @@ class ResponsesController < ApplicationController
     redirect_to(index_url_with_page_num)
   end
 
+  def possible_submitters
+    # get the users to which this response can be assigned
+    # which is the users in this mission plus the submitter of this response
+    @possible_submitters = User.assigned_to_or_submitter(current_mission, @response).by_name
+
+    # do search if applicable
+    if params[:search].present?
+      begin
+        @possible_submitters = User.do_search(@possible_submitters, params[:search])
+      rescue Search::ParseError
+        flash.now[:error] = $!.to_s
+        @search_error = true
+      end
+    end
+
+    @possible_submitters = @possible_submitters.paginate(:page => params[:page], :per_page => 20)
+
+    render json: @possible_submitters.to_json(:include_id => true)
+  end
+
   private
     # loads the response with its associations
     def load_with_associations
@@ -206,10 +226,6 @@ class ResponsesController < ApplicationController
 
     # prepares objects for and renders the form template
     def prepare_and_render_form
-      # get the users to which this response can be assigned
-      # which is the users in this mission plus the submitter of this response
-      @possible_submitters = User.assigned_to_or_submitter(current_mission, @response).by_name
-
       # render the form
       render(:form)
     end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -46,6 +46,8 @@ module ApplicationHelper
   # defaults to using .name and .id, but other methods can be specified, including Procs
   # if :tags is set, returns the <option> tags instead of just the array
   def sel_opts_from_objs(objs, options = {})
+    objs = Array.wrap(objs)
+
     # set default method names
     id_m = options[:id_method] ||= "id"
     name_m = options[:name_method] ||= "name"

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -260,9 +260,9 @@ class User < ActiveRecord::Base
   end
 
   def as_json(options = {})
-    json = {:name => name}
-    json[:id] = id if options[:include_id]
-    json
+    options[:only] ||= [:name]
+
+    super
   end
 
   # returns hash of missions to roles

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -260,7 +260,9 @@ class User < ActiveRecord::Base
   end
 
   def as_json(options = {})
-    {:name => name}
+    json = {:name => name}
+    json[:id] = id if options[:include_id]
+    json
   end
 
   # returns hash of missions to roles

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -15,8 +15,10 @@
   <link href='//fonts.googleapis.com/css?family=Raleway:400,700' rel='stylesheet' type='text/css'>
   <link href='//fonts.googleapis.com/css?family=Open+Sans:400italic,400,700' rel='stylesheet' type='text/css'>
   <link href="//netdna.bootstrapcdn.com/font-awesome/4.0.3/css/font-awesome.css" rel="stylesheet">
+  <link href="//cdnjs.cloudflare.com/ajax/libs/select2/4.0.0/css/select2.min.css" rel="stylesheet" />
   <script src="//cdn.ckeditor.com/4.4.1/basic/ckeditor.js"></script>
   <%= javascript_include_tag "application" %>
+  <script src="//cdnjs.cloudflare.com/ajax/libs/select2/4.0.0/js/select2.min.js"></script>
   <%= csrf_meta_tags %>
 
   <%= javascript_doc_ready do %>

--- a/app/views/responses/form.html.erb
+++ b/app/views/responses/form.html.erb
@@ -20,7 +20,7 @@
   <%= f.field(:form_id, :content => link_to(@response.form.name, @response.form)) %>
 
   <%# if the user can't manage the response, then don't show the submitter box as a dropdown %>
-  <%= f.field(:user_id, :type => :select, :required => true, :options => sel_opts_from_objs(@possible_submitters),
+  <%= f.field(:user_id, :type => :select, :required => true, :options => sel_opts_from_objs(@response.user),
     :read_only => cannot?(:manage, @response),
 
     # some users are not linkable currently if they're not assigned to the mission
@@ -57,5 +57,7 @@
 
 <%= javascript_doc_ready do %>
   $('textarea').each(function(){ CKEDITOR.replace(this.id); });
-  ELMO.Response.init();
+  ELMO.Response.init(<%=json({
+    url: possible_submitters_responses_path(id: @response.id)
+  })%>);
 <% end %>

--- a/app/views/responses/form.html.erb
+++ b/app/views/responses/form.html.erb
@@ -58,6 +58,6 @@
 <%= javascript_doc_ready do %>
   $('textarea').each(function(){ CKEDITOR.replace(this.id); });
   ELMO.Response.init(<%=json({
-    url: possible_submitters_responses_path(id: @response.id)
+    url: @response.new_record? ? possible_submitters_new_response_path : possible_submitters_response_path(@response)
   })%>);
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -50,8 +50,8 @@ ELMO::Application.routes.draw do
       end
     end
     resources :responses do
-      collection do
-        get 'possible_submitters', path: 'possible-submitters'
+      %i(new member).each do |type|
+        get 'possible_submitters', path: 'possible-submitters', on: type
       end
     end
     resources :sms, only: [:index]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -49,7 +49,11 @@ ELMO::Application.routes.draw do
         post 'new_with_users', path: 'new-with-users'
       end
     end
-    resources :responses
+    resources :responses do
+      collection do
+        get 'possible_submitters', path: 'possible-submitters'
+      end
+    end
     resources :sms, only: [:index]
     resources :sms_tests, path: 'sms-tests'
 

--- a/spec/features/responses_form_spec.rb
+++ b/spec/features/responses_form_spec.rb
@@ -15,7 +15,7 @@ feature 'responses form', js: true, sphinx: true do
       login(@user)
     end
 
-    scenario 'should work' do
+    xscenario 'should work' do
       visit_submit_page_and_select_user
 
       # Fill in answers
@@ -83,7 +83,7 @@ feature 'responses form', js: true, sphinx: true do
       login(@user)
     end
 
-    scenario 'should be properly ignored' do
+    xscenario 'should be properly ignored' do
       visit_submit_page_and_select_user
 
       expect(page).not_to have_selector("div.form_field#qing_#{@qing1.id}")
@@ -105,7 +105,7 @@ feature 'responses form', js: true, sphinx: true do
       login(@user)
     end
 
-    scenario 'should be enforced if appropriate' do
+    xscenario 'should be enforced if appropriate' do
       # Should raise error if value filled in.
       visit_submit_page_and_select_user
       fill_in(control_id(@qings[0], '_value'), with: '9')

--- a/spec/features/responses_form_spec.rb
+++ b/spec/features/responses_form_spec.rb
@@ -15,7 +15,7 @@ feature 'responses form', js: true, sphinx: true do
       login(@user)
     end
 
-    xscenario 'should work' do
+    scenario 'should work' do
       visit_submit_page_and_select_user
 
       # Fill in answers
@@ -83,7 +83,7 @@ feature 'responses form', js: true, sphinx: true do
       login(@user)
     end
 
-    xscenario 'should be properly ignored' do
+    scenario 'should be properly ignored' do
       visit_submit_page_and_select_user
 
       expect(page).not_to have_selector("div.form_field#qing_#{@qing1.id}")
@@ -105,7 +105,7 @@ feature 'responses form', js: true, sphinx: true do
       login(@user)
     end
 
-    xscenario 'should be enforced if appropriate' do
+    scenario 'should be enforced if appropriate' do
       # Should raise error if value filled in.
       visit_submit_page_and_select_user
       fill_in(control_id(@qings[0], '_value'), with: '9')
@@ -131,7 +131,7 @@ feature 'responses form', js: true, sphinx: true do
 
   def visit_submit_page_and_select_user
     visit(new_response_path(locale: 'en', mode: 'm', mission_name: get_mission.compact_name, form_id: @form.id))
-    select(@user.name, from: 'response_user_id')
+    select2(@user.name, from: 'response_user_id')
   end
 
   def check_response_show_form(*values)

--- a/spec/support/capybara/select2_helper.rb
+++ b/spec/support/capybara/select2_helper.rb
@@ -1,0 +1,24 @@
+module Select2Helper
+  def select2(value, options={})
+    # invoke the select2 open action via JS
+    execute_script("$('##{options[:from]}').select2('open')")
+
+    # get the $results element from the Select2 data structure
+    results_id = evaluate_script("$('##{options[:from]}').data('select2').$results.attr('id')")
+    expect(results_id).to be_present
+
+    # find the results element
+    results = find_by_id(results_id)
+
+    # wait for an LI to become available with the expected value, then click it
+    expect(results.find('li')).to have_content(value)
+    results.first('li', value).click
+
+    # assert that the original select field was updated with the intended value
+    select(value, options)
+  end
+end
+
+RSpec.configure do |config|
+  config.include Select2Helper, type: :feature
+end


### PR DESCRIPTION
Uses the [Select2](https://select2.github.io/) library with remote data loading for the `Response.user_id` dropdown.

Also adds a `select2` helper for Capybara that should be able to replace `select` as needed.