### PR TITLE
2469: Make backtraces show up for feature spec failures

### DIFF
--- a/app/controllers/sms_controller.rb
+++ b/app/controllers/sms_controller.rb
@@ -1,5 +1,9 @@
 # handles incoming sms messages from various providers
 class SmsController < ApplicationController
+  rescue_from Sms::UnverifiedTokenError do |exception|
+    render plain: 'Unauthorized', status: :unauthorized
+  end
+
   # load resource for index
   load_and_authorize_resource :class => "Sms::Message", :only => :index
 
@@ -26,7 +30,7 @@ class SmsController < ApplicationController
 
   def create
     if params[:token] != current_mission.setting.incoming_sms_token
-      raise Sms::Error.new("Could not verify incoming SMS token")
+      raise Sms::UnverifiedTokenError
     end
 
     @incoming_adapter = Sms::Adapters::Factory.new.create_for_request(request)

--- a/app/models/sms/unverified_token_error.rb
+++ b/app/models/sms/unverified_token_error.rb
@@ -1,0 +1,8 @@
+module Sms
+  class UnverifiedTokenError < Error
+    def initialize(message=nil)
+      message ||= 'Could not verify incoming SMS token'
+      super
+    end
+  end
+end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -15,7 +15,7 @@ ELMO::Application.configure do
   config.action_controller.perform_caching = false
 
   # Raise exceptions instead of rendering exception templates
-  config.action_dispatch.show_exceptions = true
+  config.action_dispatch.show_exceptions = false
 
   # Disable request forgery protection in test environment
   config.action_controller.allow_forgery_protection    = false

--- a/spec/controllers/odk_submission_spec.rb
+++ b/spec/controllers/odk_submission_spec.rb
@@ -40,8 +40,7 @@ describe 'odk submissions', type: :request do
     end
 
     it 'should fail for non-existent mission' do
-      do_submission('/m/foo/submission')
-      expect(response.response_code).to eq 404
+      expect { do_submission('/m/foo/submission') }.to raise_error(ActiveRecord::RecordNotFound)
     end
 
     it 'should return error 426 upgrade required if old version of form' do

--- a/spec/requests/incoming_sms_spec.rb
+++ b/spec/requests/incoming_sms_spec.rb
@@ -145,7 +145,7 @@ describe 'incoming sms' do
 
     do_incoming_request(url: "/m/#{get_mission.compact_name}/sms/submit/#{token}",
       incoming: {body: "#{form_code} 1.15 2.20", adapter: REPLY_VIA_RESPONSE_STYLE_ADAPTER})
-    expect(@response.status).to eq(500)
+    expect(@response.status).to eq(401)
   end
 
   private


### PR DESCRIPTION
By setting `config.action_dispatch.show_exceptions` to `false`, Capybara is able to recover the exception that caused a 500 error and show it in the console on test failure.

Turning off the `show_exceptions` flag turns off the default translation of a few exceptions like `ActiveRecord::RecordNotFound` into their corresponding HTTP status codes (e.g. 404 Not Found in the case of `ActiveRecord::RecordNotFound`). I've updated one spec to catch `ActiveRecord::RecordNotFound` instead of expecting a 404, but another approach later could be add an explicit `rescue_from` for `ActiveRecord::RecordNotFound`.