### PR TITLE
2319: Fix detection of incomplete forms

### DIFF
--- a/app/models/condition.rb
+++ b/app/models/condition.rb
@@ -96,7 +96,7 @@ class Condition < ActiveRecord::Base
 
     if ref_qing.has_options?
 
-      selected = "selected(#{lhs}, 'on#{option_nodes.last.id}')"
+      selected = "selected(#{lhs}, '#{option_nodes.last.odk_code}')"
 
       # Apply negation if appropriate.
       %w(neq ninc).include?(operator[:name]) ? "not(#{selected})" : selected

--- a/app/models/condition.rb
+++ b/app/models/condition.rb
@@ -39,6 +39,10 @@ class Condition < ActiveRecord::Base
     option_ids.nil? ? nil : Option.find(option_ids).sort_by{ |o| option_ids.index(o.id) }
   end
 
+  def option_nodes
+    option_ids.nil? ? nil : OptionNode.where(option_id: option_ids, option_set_id: ref_qing.option_set).sort_by { |on| option_ids.index(on.option_id) }
+  end
+
   def option
     options.try(:first)
   end
@@ -92,7 +96,7 @@ class Condition < ActiveRecord::Base
 
     if ref_qing.has_options?
 
-      selected = "selected(#{lhs}, '#{option_ids.last}')"
+      selected = "selected(#{lhs}, 'on#{option_nodes.last.id}')"
 
       # Apply negation if appropriate.
       %w(neq ninc).include?(operator[:name]) ? "not(#{selected})" : selected

--- a/app/models/itemsets_form_attachment.rb
+++ b/app/models/itemsets_form_attachment.rb
@@ -89,9 +89,9 @@ class ItemsetsFormAttachment
 
     # Generates a CSV row for a normal node.
     def option_row(node)
-      row = ["os#{node.option_set_id}", "on#{node.id}"]
+      row = ["os#{node.option_set_id}", node.odk_code]
       row += configatron.preferred_locales.map{ |l| node.option.name(l) } # Names
-      row << (node.depth > 1 ? "on#{node.parent_id}" : nil) # Node ID and parent node ID (unless parent is root)
+      row << (node.depth > 1 ? node.parent_odk_code : nil) # Node ID and parent node ID (unless parent is root)
       row
     end
 
@@ -100,7 +100,7 @@ class ItemsetsFormAttachment
     def none_row(node, options)
       row = ["os#{node.option_set_id}", 'none']
       row += configatron.preferred_locales.map{ |l| "[#{I18n.t('common.blank', locale: l)}]" }
-      row << (options[:type] == :child ? "on#{node.id}" : 'none')
+      row << (options[:type] == :child ? node.odk_code : 'none')
       row
     end
   end

--- a/app/models/option_node.rb
+++ b/app/models/option_node.rb
@@ -165,6 +165,15 @@ class OptionNode < ActiveRecord::Base
     end
   end
 
+  # an odk-friendly unique code
+  def odk_code
+    "on#{id}"
+  end
+
+  # an odk-friendly unique code for this node's parent
+  def parent_odk_code
+    "on#{parent_id}"
+  end
 
   # Serializes all descendants. Meant to be called on root.
   def as_json(options = {})

--- a/app/models/response.rb
+++ b/app/models/response.rb
@@ -393,9 +393,9 @@ class Response < ActiveRecord::Base
           answer = Answer.new(questioning: qing, rank: subq.rank)
           answer.populate_from_string(hash[subq.odk_code])
           self.answers << answer
-          self.incomplete = true if answer.required_but_empty?
         end
       end
+      self.incomplete = (hash[OdkHelper::IR_QUESTION] == 'yes')
     end
 
     def answer_set_for_questioning(questioning)

--- a/spec/controllers/odk_submission_spec.rb
+++ b/spec/controllers/odk_submission_spec.rb
@@ -101,7 +101,7 @@ describe 'odk submissions', type: :request do
     end
 
     it 'should be marked incomplete iff there is an incomplete response to a required question' do
-      form = create(:form, question_types: %w(integer))
+      form = create(:form, question_types: %w(integer), allow_incomplete: true)
       form.c[0].update_attributes!(required: true)
       form.reload.publish!
 
@@ -157,7 +157,11 @@ describe 'odk submissions', type: :request do
     ''.tap do |xml|
       xml << "<?xml version='1.0' ?><data id=\"#{form_id}\" version=\"#{form.current_version.sequence}\">"
 
-      unless options[:no_answers]
+      if options[:no_answers]
+        if form.allow_incomplete?
+          xml << "<#{OdkHelper::IR_QUESTION}>yes</#{OdkHelper::IR_QUESTION}>"
+        end
+      else
         form.questionings.each_with_index do |qing, i|
           xml << "<#{qing.question.odk_code}>#{(i+1)*5}</#{qing.question.odk_code}>"
         end

--- a/spec/models/condition_spec.rb
+++ b/spec/models/condition_spec.rb
@@ -73,18 +73,19 @@ describe Condition do
     context 'for single level select one question' do
       before do
         @form = create(:form, question_types: %w(select_one))
-        @qing = @form.questionings[0]
-        @options = @qing.options
+        @qing = @form.questionings.first
+        @option = @qing.options.first
+        @option_node = @option.option_nodes.where(option_set_id: @qing.option_set).first
       end
 
       it 'should work with eq operator' do
-        c = Condition.new(ref_qing: @qing, op: 'eq', option_ids: [@options[0].id])
-        expect(c.to_odk).to eq "selected(/data/#{@qing.odk_code}, '#{@options[0].id}')"
+        c = Condition.new(ref_qing: @qing, op: 'eq', option_ids: [@option.id])
+        expect(c.to_odk).to eq "selected(/data/#{@qing.odk_code}, 'on#{@option_node.id}')"
       end
 
       it 'should work with neq operator' do
-        c = Condition.new(ref_qing: @qing, op: 'neq', option_ids: [@options[0].id])
-        expect(c.to_odk).to eq "not(selected(/data/#{@qing.odk_code}, '#{@options[0].id}'))"
+        c = Condition.new(ref_qing: @qing, op: 'neq', option_ids: [@option.id])
+        expect(c.to_odk).to eq "not(selected(/data/#{@qing.odk_code}, 'on#{@option_node.id}'))"
       end
     end
 
@@ -96,13 +97,13 @@ describe Condition do
       end
 
       it 'should work for first level' do
-        c = Condition.new(ref_qing: @qing, op: 'eq', option_ids: [@oset.c[0].id])
-        expect(c.to_odk).to eq "selected(/data/#{@qing.subquestions[0].odk_code}, '#{@oset.c[0].id}')"
+        c = Condition.new(ref_qing: @qing, op: 'eq', option_ids: [@oset.c[0].option_id])
+        expect(c.to_odk).to eq "selected(/data/#{@qing.subquestions[0].odk_code}, 'on#{@oset.c[0].id}')"
       end
 
       it 'should work for second level' do
-        c = Condition.new(ref_qing: @qing, op: 'eq', option_ids: [@oset.c[0].id, @oset.c[0].c[1].id])
-        expect(c.to_odk).to eq "selected(/data/#{@qing.subquestions[1].odk_code}, '#{@oset.c[0].c[1].id}')"
+        c = Condition.new(ref_qing: @qing, op: 'eq', option_ids: [@oset.c[0].option_id, @oset.c[0].c[1].option_id])
+        expect(c.to_odk).to eq "selected(/data/#{@qing.subquestions[1].odk_code}, 'on#{@oset.c[0].c[1].id}')"
       end
     end
 
@@ -111,16 +112,19 @@ describe Condition do
         @form = create(:form, question_types: %w(select_multiple))
         @qing = @form.questionings[0]
         @options = @qing.options
+        @option_nodes = OptionNode.where(option_id: @options.map(&:id), option_set_id: @qing.option_set).sort_by do |on|
+          @options.index { |o| o.id == on.option_id }
+        end
       end
 
       it 'should work with inc operator' do
         c = Condition.new(ref_qing: @qing, op: 'inc', option_ids: [@options[0].id])
-        expect(c.to_odk).to eq "selected(/data/#{@qing.odk_code}, '#{@options[0].id}')"
+        expect(c.to_odk).to eq "selected(/data/#{@qing.odk_code}, 'on#{@option_nodes[0].id}')"
       end
 
       it 'should work with ninc operator' do
         c = Condition.new(ref_qing: @qing, op: 'ninc', option_ids: [@options[1].id])
-        expect(c.to_odk).to eq "not(selected(/data/#{@qing.odk_code}, '#{@options[1].id}'))"
+        expect(c.to_odk).to eq "not(selected(/data/#{@qing.odk_code}, 'on#{@option_nodes[1].id}'))"
       end
     end
 


### PR DESCRIPTION
Forms submitted through ODK while missing values that were conditionally required were being marked as incomplete. ELMO now trusts the `<ir01>` value submitted by the ODK client to detect incomplete responses and relies on the client correctly enforcing which answers are required.

This PR also fixes the handling of conditionally required questions in ODK, which appears to have broken in commit 3cc61489ba5ae0462eac37382b03e2c69fb9e9c0.
