### PR TITLE
2375: Fix blank values in report

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -111,6 +111,7 @@ group :development, :test do
   gem 'factory_girl_rails', '~> 4.0'
   gem 'jasmine-rails', '~> 0.10.7'   # test framework
   gem 'rspec-rails', '~> 3.0'        # test framework
+  gem 'rspec-collection_matchers'
   gem 'mocha'                        # mocking/stubbing
   gem 'capybara'                     # acceptance tests
   gem 'selenium-webdriver'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -268,6 +268,8 @@ GEM
       nokogiri
       rubyzip
       spreadsheet (> 0.6.4)
+    rspec-collection_matchers (1.1.2)
+      rspec-expectations (>= 2.99.0.beta1)
     rspec-core (3.2.2)
       rspec-support (~> 3.2.0)
     rspec-expectations (3.2.0)
@@ -420,6 +422,7 @@ DEPENDENCIES
   responders (~> 2.0)
   reverse_markdown
   roo
+  rspec-collection_matchers
   rspec-rails (~> 3.0)
   sass-rails (~> 4.0.2)
   scrypt (= 1.2)

--- a/app/models/report/summary_collection_builder.rb
+++ b/app/models/report/summary_collection_builder.rb
@@ -118,7 +118,7 @@ class Report::SummaryCollectionBuilder
     # builds and executes a query for summary info for stat questions
     # returns a hash of the form {[disagg_value, qing_id] => {'mean' => x.x, 'min' => x, 'max' => x}, ...}
     def run_stat_query(stat_qs)
-      qing_ids = stat_qs.map(&:id).join(',')
+      qing_ids = stat_qs.map(&:id)
 
       query = <<-eos
         SELECT #{disagg_select_expr} qing.id AS qing_id, q.qtype_name AS qtype_name,
@@ -173,7 +173,7 @@ class Report::SummaryCollectionBuilder
     ####################################################################
 
     def collection_for_select_questionings(select_qs)
-      qing_ids = select_qs.map(&:id).join(',')
+      qing_ids = select_qs.map(&:id)
 
       # get tallies of answers
       tallies = get_select_question_tallies(qing_ids)
@@ -358,7 +358,7 @@ class Report::SummaryCollectionBuilder
 
     # gets tallies of dates and answers for each of the given questionings
     def get_date_question_tallies(date_qs)
-      qing_ids = date_qs.map(&:id).join(',')
+      qing_ids = date_qs.map(&:id)
 
       # build and run query
       query = <<-eos
@@ -460,7 +460,7 @@ class Report::SummaryCollectionBuilder
     # runs a query to get each answer for the given qings
     # returns a mysql result
     def run_raw_answer_query(raw_qs)
-      qing_ids = raw_qs.map(&:id).join(',')
+      qing_ids = raw_qs.map(&:id)
 
       # build and run query
       query = <<-eos

--- a/spec/models/report/summary_collection_single_spec.rb
+++ b/spec/models/report/summary_collection_single_spec.rb
@@ -35,8 +35,8 @@ describe "summary collection with single subset" do
     prepare_form_and_collection('integer', [1])
     items = first_summary.items
     expect(items[0].stat.class).to eq(Float) # mean
-    expect(items[1].stat.class).to eq(Fixnum) # max
-    expect(items[2].stat.class).to eq(Fixnum) # min
+    expect(items[1].stat.class).to eq(Fixnum) # min
+    expect(items[2].stat.class).to eq(Fixnum) # max
   end
 
   it "null_count should be correct for integer" do
@@ -68,8 +68,8 @@ describe "summary collection with single subset" do
     prepare_form_and_collection('decimal', [1])
     items = first_summary.items
     expect(items[0].stat.class).to eq(Float) # mean
-    expect(items[1].stat.class).to eq(Float) # max
-    expect(items[2].stat.class).to eq(Float) # min
+    expect(items[1].stat.class).to eq(Float) # min
+    expect(items[2].stat.class).to eq(Float) # max
   end
 
   it "select_one summary should be correct in normal case" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,7 @@
 ENV["RAILS_ENV"] ||= 'test'
 require File.expand_path("../../config/environment", __FILE__)
 require 'rspec/rails'
+require 'rspec/collection_matchers'
 
 # Add this to load Capybara integration:
 require 'capybara/rspec'


### PR DESCRIPTION
I spent some time trying to create a test for this, but I wasn't able to figure it out in a reasonable amount of time. The `rspec-collection_matchers` gem was added to support an abortive attempt at testing the case where `qing_ids` has more than one value.