### PR TITLE
2337: Allow options to have geographic coordinates

### DIFF
--- a/app/assets/javascripts/backbone/views/answer_map_view.js.coffee
+++ b/app/assets/javascripts/backbone/views/answer_map_view.js.coffee
@@ -1,0 +1,28 @@
+class ELMO.Views.AnswerMapView extends Backbone.View
+
+  initialize: (params) ->
+    # create the map
+    @map = new google.maps.Map(this.$el[0], {
+      mapTypeId: google.maps.MapTypeId.ROADMAP,
+      disableDefaultUI: true,
+      maxZoom: 11,
+      zoomControl: true,
+      zoomControlOptions: {
+        position: google.maps.ControlPosition.TOP_RIGHT,
+        style: google.maps.ZoomControlStyle.SMALL
+      }
+    })
+
+    # add a marker for each option and calculate bounds
+    bounds = new google.maps.LatLngBounds()
+    for o in params.options
+      p = new google.maps.LatLng(o.latitude, o.longitude)
+      m = new google.maps.Marker({
+        map: @map,
+        position: p,
+        icon: params.small_marker_url
+      })
+      bounds.extend(p)
+
+    # set the bounds
+    @map.fitBounds(bounds)

--- a/app/assets/javascripts/models/option_node.js
+++ b/app/assets/javascripts/models/option_node.js
@@ -8,10 +8,14 @@
     // copy attribs
     for (var key in attribs) self[key] = attribs[key];
 
-    // also translations from option. these are the ones we'll actually use.
     if (self.option) {
+      // also translations from option. these are the ones we'll actually use.
       self.name = self.option.name;
       self.name_translations = self.option.name_translations;
+
+      // copy coordinates
+      self.latitude = self.option.latitude;
+      self.longitude = self.option.longitude;
     }
 
     // names are editable if the node is not a new record
@@ -31,5 +35,10 @@
   klass.prototype = new ns.NamedItem();
   klass.prototype.constructor = klass;
   klass.prototype.parent = ns.NamedItem.prototype;
+
+  // update the latitude/longitude value
+  klass.prototype.update_coordinate = function (params) { var self = this;
+    self[params.field] = params.value;
+  };
 
 })(ELMO.Models);

--- a/app/assets/javascripts/views/draggable_list.js
+++ b/app/assets/javascripts/views/draggable_list.js
@@ -235,7 +235,7 @@
     self.modal.find('.modal-title').text(self.modal_titles[options.mode]);
 
     // clear the text boxes
-    self.modal.find('.translation input').val("");
+    self.modal.find('input[type=text], input[type=number]').val("");
 
     // hide the in_use warning
     self.modal.find('div[id$=in_use_name_change_warning]').hide();
@@ -244,6 +244,10 @@
     self.active_item.locales().forEach(function(l){
       self.modal.find('.translation input[id$=name_' + l + ']').val(self.active_item.translation(l));
     });
+
+    // populate coordinates
+    self.modal.find('.coordinate input[id=option_latitude]').val(self.active_item.latitude);
+    self.modal.find('.coordinate input[id=option_longitude]').val(self.active_item.longitude);
 
     // show the modal
     self.modal.modal('show');
@@ -278,6 +282,10 @@
   klass.prototype.save_item = function() { var self = this;
     self.modal.find('.translation input').each(function(){
       self.active_item.update_translation({field: 'name', locale: $(this).data('locale'), value: $(this).val()});
+    });
+
+    self.modal.find('.coordinate input').each(function(){
+      self.active_item.update_coordinate({field: $(this).data('field'), value: $(this).val()});
     });
 
     self.wrapper.show();

--- a/app/assets/javascripts/views/draggable_list.js
+++ b/app/assets/javascripts/views/draggable_list.js
@@ -246,8 +246,15 @@
     });
 
     // populate coordinates
-    self.modal.find('.coordinate input[id=option_latitude]').val(self.active_item.latitude);
-    self.modal.find('.coordinate input[id=option_longitude]').val(self.active_item.longitude);
+    if (self.allow_coordinates) {
+      self.modal.find('.coordinate').show();
+      self.modal.find('.coordinate input').attr('disabled', false);
+      self.modal.find('.coordinate input[id=option_latitude]').val(self.active_item.latitude);
+      self.modal.find('.coordinate input[id=option_longitude]').val(self.active_item.longitude);
+    } else {
+      self.modal.find('.coordinate').hide();
+      self.modal.find('.coordinate input').attr('disabled', true);
+    }
 
     // show the modal
     self.modal.modal('show');

--- a/app/assets/javascripts/views/option_set_form.js
+++ b/app/assets/javascripts/views/option_set_form.js
@@ -50,6 +50,10 @@
     $('#option_set_geographic').on('change', function() { self.geographic_changed(); });
     self.geographic_changed();
 
+    // watch for changes to allow_coordinates property
+    $('#option_set_allow_coordinates').on('change', function() { self.allow_coordinates_changed(); });
+    self.allow_coordinates_changed();
+
     // watch for changes to multilevel property
     $('#option_set_multi_level').on('change', function() { self.multilevel_changed(); });
     self.multilevel_changed();
@@ -116,6 +120,19 @@
       self.allow_coordinates_field.hide();
       self.allow_coordinates_field.find('input[type=checkbox]').attr('checked', false);
     }
+  };
+
+  // reacts to changes to allow_coordinates checkbox
+  klass.prototype.allow_coordinates_changed = function() { var self = this;
+    var checked;
+    // Check if allow_coordinates checkbox is read only
+    if ($('#allow_coordinates div.ro-val').length > 0)
+      checked = $('#allow_coordinates div.ro-val').data('val');
+    else
+      checked = $('#option_set_allow_coordinates').is(':checked');
+
+    // Update whether coordinates can be edited in the options_field
+    self.options_field.list.allow_coordinates = checked;
   };
 
   // reacts to changes to multilevel checkbox

--- a/app/assets/javascripts/views/option_set_form.js
+++ b/app/assets/javascripts/views/option_set_form.js
@@ -209,7 +209,7 @@
       data.option_set.children_attribs = self.prepare_options();
     }
 
-    // Upate some params OptionSet model, as this may be used by modal
+    // Update some params OptionSet model, as this may be used by modal
     self.params.option_set.name = data['option_set[name]'];
     self.params.option_set.multi_level = data['option_set[multi_level]'] == '1';
 

--- a/app/assets/javascripts/views/option_set_form.js
+++ b/app/assets/javascripts/views/option_set_form.js
@@ -237,7 +237,7 @@
   klass.prototype.prepare_option_tree = function(nodes) { var self = this;
     return nodes.map(function(node){
       // in this case, the item will be an Optioning, which is also a NamedItem
-      var prepared = {option_attribs: {name_translations: node.item.name_translations}};
+      var prepared = {option_attribs: {name_translations: node.item.name_translations, latitude: node.item.latitude, longitude: node.item.longitude}};
 
       // include IDs if available
       if (node.item.id)

--- a/app/assets/javascripts/views/option_set_form.js
+++ b/app/assets/javascripts/views/option_set_form.js
@@ -34,6 +34,9 @@
       remove_link: self.params.remove_link
     });
 
+    // find the allow_coordinates field
+    self.allow_coordinates_field = $('.form_field[data-field-name=allow_coordinates]');
+
     // add option button click event
     $('div.add_options input[type=button]').on('click', function() { self.add_options(); });
 
@@ -42,6 +45,10 @@
       self.option_levels_field.add();
       e.preventDefault();
     });
+
+    // watch for changes to geographic property
+    $('#option_set_geographic').on('change', function() { self.geographic_changed(); });
+    self.geographic_changed();
 
     // watch for changes to multilevel property
     $('#option_set_multi_level').on('change', function() { self.multilevel_changed(); });
@@ -91,6 +98,24 @@
   klass.prototype.enable_multilevel_checkbox = function() { var self = this;
     $('#option_set_multi_level').prop('disabled',
       !(self.option_levels_field.list.count() == 0 && self.options_field.list.max_depth() <= 1));
+  };
+
+  // reacts to changes to geographic checkbox
+  klass.prototype.geographic_changed = function() { var self = this;
+    var checked;
+    // Check if geographic checkbox is read only
+    if ($('#geographic div.ro-val').length > 0)
+      checked = $('#geographic div.ro-val').data('val');
+    else
+      checked = $('#option_set_geographic').is(':checked');
+
+    // show/hide the allow coordinates field
+    if (checked) {
+      self.allow_coordinates_field.show();
+    } else {
+      self.allow_coordinates_field.hide();
+      self.allow_coordinates_field.find('input[type=checkbox]').attr('checked', false);
+    }
   };
 
   // reacts to changes to multilevel checkbox

--- a/app/assets/javascripts/views/option_set_form.js
+++ b/app/assets/javascripts/views/option_set_form.js
@@ -254,7 +254,7 @@
   klass.prototype.prepare_option_tree = function(nodes) { var self = this;
     return nodes.map(function(node){
       // in this case, the item will be an Optioning, which is also a NamedItem
-      var prepared = {option_attribs: {name_translations: node.item.name_translations, latitude: node.item.latitude, longitude: node.item.longitude}};
+      var prepared = {option_attribs: {name_translations: node.item.name_translations}};
 
       // include IDs if available
       if (node.item.id)
@@ -262,6 +262,12 @@
 
       if (node.item.option.id)
         prepared.option_attribs.id = node.item.option.id;
+
+      // include latitude and longitude if allow_coordinates is set
+      if ($('#option_set_allow_coordinates').is(':checked')) {
+        prepared.option_attribs.latitude = node.item.latitude;
+        prepared.option_attribs.longitude = node.item.longitude;
+      }
 
       // recurse
       prepared.children_attribs = node.children && node.children.length ? self.prepare_option_tree(node.children) : 'NONE';

--- a/app/assets/stylesheets/all/option_sets.css.scss
+++ b/app/assets/stylesheets/all/option_sets.css.scss
@@ -47,15 +47,18 @@ form.option_set_form {
 }
 
 div.modal#edit-option, div.modal#edit-option-level {
-  .translation {
+  .translation, .coordinate {
     margin-bottom: 10px;
+
     label {
       width: 40%;
     }
 
-    input[type=text] {
-      display: inline-block;
-      width: 50%;
+    input {
+      &[type=text], &[type=number] {
+        display: inline-block;
+        width: 50%;
+      }
     }
   }
 }

--- a/app/assets/stylesheets/all/option_sets.css.scss
+++ b/app/assets/stylesheets/all/option_sets.css.scss
@@ -2,9 +2,12 @@
 
 form.option_set_form {
 
-  /* hide the option levels at first */
-  div.form_field[data-field-name=option_levels] {
-    display: none;
+  /* hide the option levels and allow_coordinates at first */
+  div.form_field {
+    &[data-field-name=allow_coordinates],
+    &[data-field-name=option_levels] {
+      display: none;
+    }
   }
 
   /* special case for add options widget */

--- a/app/assets/stylesheets/all/responses.css.scss
+++ b/app/assets/stylesheets/all/responses.css.scss
@@ -60,6 +60,13 @@ $response-form-label-width: 300px;
       }
     }
   }
+
+  .answer-map {
+    width: 160px;
+    height: 80px;
+    float: right;
+    margin-bottom: 10px;
+  }
 }
 
 form.response_form {

--- a/app/assets/stylesheets/screen/screen.css.scss
+++ b/app/assets/stylesheets/screen/screen.css.scss
@@ -205,6 +205,7 @@ nav {
           font-weight: normal;
           font-family: $sans-serif;
           font-size: 10pt;
+          display: block;
 
           &:hover, &:focus {
             background: none;

--- a/app/controllers/option_sets_controller.rb
+++ b/app/controllers/option_sets_controller.rb
@@ -153,7 +153,7 @@ class OptionSetsController < ApplicationController
   end
 
   def option_set_params
-    params.require(:option_set).permit(:name, :geographic, :multi_level,
+    params.require(:option_set).permit(:name, :geographic, :allow_coordinates, :multi_level,
       level_names: configatron.preferred_locales,
       children_attribs: permit_children(params[:option_set], key: :children_attribs, permitted: [
         :id, { option_attribs: [:id, :latitude, :longitude, { name_translations: configatron.preferred_locales }] }])

--- a/app/controllers/option_sets_controller.rb
+++ b/app/controllers/option_sets_controller.rb
@@ -156,7 +156,7 @@ class OptionSetsController < ApplicationController
     params.require(:option_set).permit(:name, :geographic, :multi_level,
       level_names: configatron.preferred_locales,
       children_attribs: permit_children(params[:option_set], key: :children_attribs, permitted: [
-        :id, { option_attribs: [:id, { name_translations: configatron.preferred_locales }] }])
+        :id, { option_attribs: [:id, :latitude, :longitude, { name_translations: configatron.preferred_locales }] }])
     )
   end
 end

--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -175,6 +175,19 @@ class Answer < ActiveRecord::Base
     end
   end
 
+  # check whether this answer has coordinates
+  def has_coordinates?
+    return false unless qtype.has_options?
+
+    if option.present?
+      # select_one
+      option.has_coordinates?
+    else
+      # select_multiple
+      choices.any? { |choice| choice.option.has_coordinates? }
+    end
+  end
+
   private
 
     def required

--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -184,7 +184,7 @@ class Answer < ActiveRecord::Base
       option.has_coordinates?
     else
       # select_multiple
-      choices.any? { |choice| choice.option.has_coordinates? }
+      choices.any?(&:has_coordinates?)
     end
   end
 

--- a/app/models/choice.rb
+++ b/app/models/choice.rb
@@ -3,6 +3,7 @@ class Choice < ActiveRecord::Base
   belongs_to(:option, :inverse_of => :choices)
 
   delegate :name, :to => :option, :prefix => true
+  delegate :has_coordinates?, :to => :option
 
   def checked
     # Only explicitly false should return false.

--- a/app/models/option.rb
+++ b/app/models/option.rb
@@ -13,6 +13,11 @@ class Option < ActiveRecord::Base
 
   translates :name
 
+  with_options if: :has_coordinates? do |geographic|
+    geographic.validates :latitude, numericality: { greater_than_or_equal_to: -90, less_than_or_equal_to: 90 }
+    geographic.validates :longitude, numericality: { greater_than_or_equal_to: -180, less_than_or_equal_to: 180 }
+  end
+
   # We re-use options on replicate if they have the same canonical_name as the option being imported.
   # Options are not standardizable so we don't track the original_id (that would be overkill).
   replicable reuse_if_match: :canonical_name
@@ -30,6 +35,8 @@ class Option < ActiveRecord::Base
   def has_choices?
     !choices.empty?
   end
+
+  def has_coordinates?; latitude.present? || longitude.present?; end
 
   # returns all forms on which this option appears
   def forms

--- a/app/models/option.rb
+++ b/app/models/option.rb
@@ -61,7 +61,7 @@ class Option < ActiveRecord::Base
 
   def as_json(options = {})
     if options[:for_option_set_form]
-      super(only: [:id, :name_translations], methods: [:name, :set_names, :in_use?])
+      super(only: [:id, :latitude, :longitude, :name_translations], methods: [:name, :set_names, :in_use?])
     else
       super(options)
     end

--- a/app/models/option.rb
+++ b/app/models/option.rb
@@ -1,15 +1,15 @@
 class Option < ActiveRecord::Base
   include MissionBased, FormVersionable, Translatable, Replication::Replicable
 
-  has_many(:option_sets, :through => :option_nodes)
-  has_many(:option_nodes, :inverse_of => :option, :dependent => :destroy, :autosave => true)
-  has_many(:answers, :inverse_of => :option)
-  has_many(:choices, :inverse_of => :option)
+  has_many(:option_sets, through: :option_nodes)
+  has_many(:option_nodes, inverse_of: :option, dependent: :destroy, autosave: true)
+  has_many(:answers, inverse_of: :option)
+  has_many(:choices, inverse_of: :option)
 
   after_save(:invalidate_cache)
   after_destroy(:invalidate_cache)
 
-  scope(:with_questions_and_forms, -> { includes(:option_sets => [:questionings, {:questions => {:questionings => :form}}]) })
+  scope(:with_questions_and_forms, -> { includes(option_sets: [:questionings, {questions: {questionings: :form}}]) })
 
   translates :name
 
@@ -54,7 +54,7 @@ class Option < ActiveRecord::Base
 
   def as_json(options = {})
     if options[:for_option_set_form]
-      super(:only => [:id, :name_translations], :methods => [:name, :set_names, :in_use?])
+      super(only: [:id, :name_translations], methods: [:name, :set_names, :in_use?])
     else
       super(options)
     end

--- a/app/models/option_set.rb
+++ b/app/models/option_set.rb
@@ -273,6 +273,7 @@ class OptionSet < ActiveRecord::Base
 
     def normalize_fields
       self.name = name.strip
+      self.allow_coordinates = false unless self.geographic?
       return true
     end
 

--- a/app/models/report/answer_tally_report.rb
+++ b/app/models/report/answer_tally_report.rb
@@ -65,7 +65,7 @@ class Report::AnswerTallyReport < Report::TallyReport
 
         # add the selects and groups
         rel = rel.select("#{name_expr_sql} AS sec_name, #{value_expr_sql} AS sec_value, #{sort_expr_sql} AS sec_sort_value, 'text' AS sec_type")
-        rel = rel.group(name_expr_sql).group(value_expr_sql).group(sort_expr_sql)
+        rel = rel.group('option_sets.name').group(name_expr_sql).group(value_expr_sql).group(sort_expr_sql)
 
         # add the unified wheres
         rel = rel.where("(" + where_exprs.collect{|e| e.sql}.join(" OR ") + ")")

--- a/app/views/option_sets/_form.html.erb
+++ b/app/views/option_sets/_form.html.erb
@@ -15,6 +15,7 @@
   <%= elmo_form_for(@option_set) do |f| %>
     <%= f.field(:name, :required => true, :read_only => cannot?(:update_core, @option_set)) %>
     <%= f.field(:geographic, :type => :check_box, :read_only => cannot?(:change_geographic, @option_set)) %>
+    <%= f.field(:allow_coordinates, :type => :check_box, :read_only => cannot?(:change_geographic, @option_set)) %>
     <%= f.field(:multi_level, :type => :check_box,
       :read_only => cannot?(:update_core, @option_set) || @option_set.has_select_multiple_questions? || @option_set.huge?) %>
     <%= f.field(:option_levels, :partial => "option_levels") %>

--- a/app/views/option_sets/_options.html.erb
+++ b/app/views/option_sets/_options.html.erb
@@ -37,6 +37,16 @@
             </div>
           <% end %>
 
+          <div class="coordinate">
+            <label for"option_latitude">Latitude</label>
+            <input type="number" step="any" class="form-control" id="option_latitude" data-field="latitude">
+          </div>
+
+          <div class="coordinate">
+            <label for"option_latitude">Longitude</label>
+            <input type="number" step="any" class="form-control" id="option_longitude" data-field="longitude">
+          </div>
+
         </div>
         <div class="modal-footer">
           <button type="button" class="btn btn-default" data-dismiss="modal"><%= I18n.t("common.cancel") %></button>

--- a/app/views/responses/_answer_map.html.erb
+++ b/app/views/responses/_answer_map.html.erb
@@ -1,0 +1,16 @@
+<div id="map_<%= answer.id %>" style="width: 160px; height: 80px; float: right; margin-bottom: 10px"></div>
+<script>
+  var coords = new google.maps.LatLng(<%= answer.option.latitude %>, <%= answer.option.longitude %>);
+  var map = new google.maps.Map($('#map_<%= answer.id %>')[0], {
+    mapTypeId: google.maps.MapTypeId.ROADMAP,
+    center: coords,
+    zoom: 10,
+    disableDefaultUI: true,
+    zoomControl: true,
+    zoomControlOptions: {
+      position: google.maps.ControlPosition.TOP_RIGHT,
+      style: google.maps.ZoomControlStyle.SMALL
+    }
+  });
+  new google.maps.Marker({ map: map, position: coords, icon: "<%= image_url('markers/small.png') %>" });
+</script>

--- a/app/views/responses/_answer_map.html.erb
+++ b/app/views/responses/_answer_map.html.erb
@@ -1,35 +1,17 @@
-<div id="map_<%= answer.id %>" class="answer-map" style="width: 160px; height: 80px; float: right; margin-bottom: 10px"></div>
+<%
+    options = if answer.option.present?
+      # select_one
+      [answer.option]
+    else
+      # select_multiple
+      answer.choices.select(&:has_coordinates?).map(&:option)
+    end
+%>
+<div id="map_<%= answer.id %>" class="answer-map"></div>
 <script>
-  var bounds = new google.maps.LatLngBounds();
-  var map = new google.maps.Map($('#map_<%= answer.id %>')[0], {
-    mapTypeId: google.maps.MapTypeId.ROADMAP,
-    zoom: 10,
-    disableDefaultUI: true,
-    zoomControl: true,
-    zoomControlOptions: {
-      position: google.maps.ControlPosition.TOP_RIGHT,
-      style: google.maps.ZoomControlStyle.SMALL
-    }
-  });
-  <% if answer.option.present? %>
-    var p = new google.maps.LatLng(<%= answer.option.latitude %>, <%= answer.option.longitude %>);
-    var m = new google.maps.Marker({
-      map: map,
-      position: p,
-      icon: "<%= image_url('markers/small.png') %>"
-    });
-    bounds.extend(p);
-  <% else %>
-    <% answer.choices.select(&:has_coordinates?).each do |choice| %>
-      var p = new google.maps.LatLng(<%= choice.option.latitude %>, <%= choice.option.longitude %>);
-      var m = new google.maps.Marker({
-        map: map,
-        position: p,
-        icon: "<%= image_url('markers/small.png') %>"
-      });
-      bounds.extend(p);
-    <% end %>
-  <% end %>
-
-  map.fitBounds(bounds);
+  new ELMO.Views.AnswerMapView(<%=json({
+    el: "#map_#{answer.id}",
+    options: options,
+    small_marker_url: image_url('markers/small.png')
+  })%>);
 </script>

--- a/app/views/responses/_answer_map.html.erb
+++ b/app/views/responses/_answer_map.html.erb
@@ -1,9 +1,8 @@
-<div id="map_<%= answer.id %>" style="width: 160px; height: 80px; float: right; margin-bottom: 10px"></div>
+<div id="map_<%= answer.id %>" class="answer-map" style="width: 160px; height: 80px; float: right; margin-bottom: 10px"></div>
 <script>
-  var coords = new google.maps.LatLng(<%= answer.option.latitude %>, <%= answer.option.longitude %>);
+  var bounds = new google.maps.LatLngBounds();
   var map = new google.maps.Map($('#map_<%= answer.id %>')[0], {
     mapTypeId: google.maps.MapTypeId.ROADMAP,
-    center: coords,
     zoom: 10,
     disableDefaultUI: true,
     zoomControl: true,
@@ -12,5 +11,25 @@
       style: google.maps.ZoomControlStyle.SMALL
     }
   });
-  new google.maps.Marker({ map: map, position: coords, icon: "<%= image_url('markers/small.png') %>" });
+  <% if answer.option.present? %>
+    var p = new google.maps.LatLng(<%= answer.option.latitude %>, <%= answer.option.longitude %>);
+    var m = new google.maps.Marker({
+      map: map,
+      position: p,
+      icon: "<%= image_url('markers/small.png') %>"
+    });
+    bounds.extend(p);
+  <% else %>
+    <% answer.choices.select(&:has_coordinates?).each do |choice| %>
+      var p = new google.maps.LatLng(<%= choice.option.latitude %>, <%= choice.option.longitude %>);
+      var m = new google.maps.Marker({
+        map: map,
+        position: p,
+        icon: "<%= image_url('markers/small.png') %>"
+      });
+      bounds.extend(p);
+    <% end %>
+  <% end %>
+
+  map.fitBounds(bounds);
 </script>

--- a/app/views/responses/_answer_read_only.html.erb
+++ b/app/views/responses/_answer_read_only.html.erb
@@ -3,28 +3,13 @@
 <% case type = answer.qtype.name
    when 'select_one' %>
 
-  <% if answer.option.has_coordinates? %>
-  <div id="map_<%= answer.id %>" style="width: 160px; height: 80px; float: right; margin-bottom: 10px"></div>
-  <script>
-    var coords = new google.maps.LatLng(<%= answer.option.latitude %>, <%= answer.option.longitude %>);
-    var map = new google.maps.Map($('#map_<%= answer.id %>')[0], {
-      mapTypeId: google.maps.MapTypeId.ROADMAP,
-      center: coords,
-      zoom: 10,
-      disableDefaultUI: true,
-      zoomControl: true,
-      zoomControlOptions: {
-        position: google.maps.ControlPosition.TOP_RIGHT,
-        style: google.maps.ZoomControlStyle.SMALL
-      }
-    });
-    new google.maps.Marker({ map: map, position: coords, icon: "<%= image_url('markers/small.png') %>" });
-  </script>
-  <% end %>
+  <%= render('answer_map', answer: answer) if answer.has_coordinates? %>
 
   <%= content_tag(:div, answer.option.try(:name), class: 'ro-val', :'data-val' => answer.option_id) %>
 
 <% when 'select_multiple' %>
+
+  <%= render('answer_map', answer: answer) if answer.has_coordinates? %>
 
   <%= content_tag(:div, safe_join(answer.choices.map{|c| c.option.name}, tag(:br)), class: 'ro-val', :'data-val' => answer.choices.map(&:option_id).to_json) %>
 

--- a/app/views/responses/_answer_read_only.html.erb
+++ b/app/views/responses/_answer_read_only.html.erb
@@ -3,6 +3,25 @@
 <% case type = answer.qtype.name
    when 'select_one' %>
 
+  <% if answer.option.has_coordinates? %>
+  <div id="map_<%= answer.id %>" style="width: 160px; height: 80px; float: right; margin-bottom: 10px"></div>
+  <script>
+    var coords = new google.maps.LatLng(<%= answer.option.latitude %>, <%= answer.option.longitude %>);
+    var map = new google.maps.Map($('#map_<%= answer.id %>')[0], {
+      mapTypeId: google.maps.MapTypeId.ROADMAP,
+      center: coords,
+      zoom: 10,
+      disableDefaultUI: true,
+      zoomControl: true,
+      zoomControlOptions: {
+        position: google.maps.ControlPosition.TOP_RIGHT,
+        style: google.maps.ZoomControlStyle.SMALL
+      }
+    });
+    new google.maps.Marker({ map: map, position: coords, icon: "<%= image_url('markers/small.png') %>" });
+  </script>
+  <% end %>
+
   <%= content_tag(:div, answer.option.try(:name), class: 'ro-val', :'data-val' => answer.option_id) %>
 
 <% when 'select_multiple' %>

--- a/app/views/responses/_answer_set.html.erb
+++ b/app/views/responses/_answer_set.html.erb
@@ -6,7 +6,7 @@
 
   <div class="label_and_control">
 
-    <label class="main"><%= reqd_sym if answer_set.required? %> <%= answer_set.question_name || "[#{t('answer.no_name')}]" %>
+    <label class="main"><%= reqd_sym if answer_set.required? %> <%= answer_set.question_name || "[#{t('answer.no_name')}]" %>:
     </label><div class="control">
       <% if answer_set.multi_level? %>
         <%# index just needs to be a unique integer, so we use the questioning ID. %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -254,6 +254,7 @@ en:
       option:
         base: "" # this is a sort of hack to get error msg to display properly
       option_set:
+        allow_coordinates: "With Coordinates?"
         answers: "Answers"
         geographic: "Is Geographic?"
         multi_level: "Is Multilevel?"
@@ -426,6 +427,7 @@ en:
       option:
         name: "The textual description of this option that users will see."
       option_set:
+        allow_coordinates: "Whether this option set allows options with geographic coordinates."
         geographic: "Whether this option set represents geographic information, e.g. a set of provinces or regions."
         name: "A name that summarizes this set of options. Normal users will not see this name."
         multi_level: "Whether the option set has multiple levels of options, such as country -> state -> city."

--- a/db/migrate/20150709233306_add_allow_coordinates_to_option_sets.rb
+++ b/db/migrate/20150709233306_add_allow_coordinates_to_option_sets.rb
@@ -1,0 +1,5 @@
+class AddAllowCoordinatesToOptionSets < ActiveRecord::Migration
+  def change
+    add_column :option_sets, :allow_coordinates, :boolean, default: false, null: false
+  end
+end

--- a/db/migrate/20150710212020_add_latitude_longitude_to_options.rb
+++ b/db/migrate/20150710212020_add_latitude_longitude_to_options.rb
@@ -1,0 +1,9 @@
+class AddLatitudeLongitudeToOptions < ActiveRecord::Migration
+  def change
+    # -90 to 90 with six decimals
+    add_column :options, :latitude, :decimal, precision: 8, scale: 6
+
+    # -180 to 180 with six decimals
+    add_column :options, :longitude, :decimal, precision: 9, scale: 6
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -223,6 +223,8 @@ ActiveRecord::Schema.define(version: 20150710150907) do
     t.integer  "mission_id",        limit: 4
     t.string   "canonical_name",    limit: 255
     t.text     "name_translations", limit: 65535
+    t.decimal  "latitude",                        precision: 8, scale: 6
+    t.decimal  "longitude",                       precision: 9, scale: 6
   end
 
   add_index "options", ["canonical_name", "mission_id"], name: "index_options_on_canonical_name_and_mission_id", using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -199,16 +199,17 @@ ActiveRecord::Schema.define(version: 20150710150907) do
   add_index "option_nodes", ["rank"], name: "index_option_nodes_on_rank", using: :btree
 
   create_table "option_sets", force: :cascade do |t|
-    t.string   "name",          limit: 255
+    t.string   "name",              limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.integer  "mission_id",    limit: 4
-    t.boolean  "is_standard",   limit: 1,     default: false
-    t.integer  "original_id",   limit: 4
-    t.boolean  "geographic",    limit: 1,     default: false, null: false
-    t.integer  "root_node_id",  limit: 4
-    t.text     "level_names",   limit: 65535
-    t.boolean  "standard_copy", limit: 1,     default: false, null: false
+    t.integer  "mission_id",        limit: 4
+    t.boolean  "is_standard",       limit: 1,     default: false
+    t.integer  "original_id",       limit: 4
+    t.boolean  "geographic",        limit: 1,     default: false, null: false
+    t.integer  "root_node_id",      limit: 4
+    t.text     "level_names",       limit: 65535
+    t.boolean  "standard_copy",     limit: 1,     default: false, null: false
+    t.boolean  "allow_coordinates", limit: 1,     default: false, null: false
   end
 
   add_index "option_sets", ["geographic"], name: "index_option_sets_on_geographic", using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150710150907) do
+ActiveRecord::Schema.define(version: 20150710212020) do
 
   create_table "answers", force: :cascade do |t|
     t.integer  "response_id",    limit: 4

--- a/spec/controllers/options_controller_spec.rb
+++ b/spec/controllers/options_controller_spec.rb
@@ -12,6 +12,6 @@ describe OptionsController, type: :request do
   it 'should return matching suggestions' do
     # The response is not super correct (e.g. id = null) but all we want to
     # test is that the controller calls suggestions and converts to json
-    expect(response.body).to eq '[{"id":null,"name_translations":{"en":"foo"},"name":"foo","set_names":"","in_use?":false}]'
+    expect(response.body).to eq '[{"id":null,"name_translations":{"en":"foo"},"latitude":null,"longitude":null,"name":"foo","set_names":"","in_use?":false}]'
   end
 end

--- a/spec/factories/choices.rb
+++ b/spec/factories/choices.rb
@@ -1,0 +1,4 @@
+FactoryGirl.define do
+  factory :choice do
+  end
+end

--- a/spec/models/answer_spec.rb
+++ b/spec/models/answer_spec.rb
@@ -1,0 +1,70 @@
+require 'spec_helper'
+
+describe Answer do
+  context 'has_coordinates?' do
+    context 'with a select_one question' do
+      let(:form) { create(:form, question_types: %w(select_one)) }
+      let(:questioning) { form.questionings.first }
+      let(:option) { questioning.options.first }
+
+      it 'should return false if the selected option does not have coordinates' do
+        answer = create(:answer, option: option, questioning: questioning)
+        expect(answer.has_coordinates?).to be_falsy
+      end
+
+      it 'should return true if the selected option has coordinates' do
+        questioning.option_set.update_attributes(geographic: true, allow_coordinates: true)
+        option.update_attributes(latitude: 0, longitude: 0)
+
+        answer = create(:answer, option: option, questioning: questioning)
+        expect(answer.has_coordinates?).to be_truthy
+      end
+    end
+
+    context 'with a select_multiple question' do
+      let(:form) { create(:form, question_types: %w(select_multiple)) }
+      let(:questioning) { form.questionings.first }
+      let(:option_one) { questioning.options.first }
+      let(:option_two) { questioning.options.second }
+
+      it 'should return false if no options were selected' do
+        answer = create(:answer, questioning: questioning)
+        expect(answer.has_coordinates?).to be_falsy
+      end
+
+      it 'should return false if the selected options do not have coordinates' do
+        answer = create(:answer, questioning: questioning)
+        create(:choice, answer: answer, option: option_one)
+        create(:choice, answer: answer, option: option_two)
+        answer.reload
+
+        expect(answer.has_coordinates?).to be_falsy
+      end
+
+      it 'should return true if all of the selected options have coordinates' do
+        questioning.option_set.update_attributes(geographic: true, allow_coordinates: true)
+        option_one.update_attributes(latitude: 0, longitude: 0)
+        option_two.update_attributes(latitude: 0, longitude: 0)
+
+        answer = create(:answer, questioning: questioning)
+        create(:choice, answer: answer, option: option_one)
+        create(:choice, answer: answer, option: option_two)
+        answer.reload
+
+        expect(answer.has_coordinates?).to be_truthy
+      end
+
+      it 'should return true if any of the selected options have coordinates' do
+        questioning.option_set.update_attributes(geographic: true, allow_coordinates: true)
+        option_one.update_attributes(latitude: 0, longitude: 0)
+
+        answer = create(:answer, questioning: questioning)
+        create(:choice, answer: answer, option: option_one)
+        create(:choice, answer: answer, option: option_two)
+        answer.reload
+
+        expect(answer.has_coordinates?).to be_truthy
+      end
+    end
+  end
+end

--- a/spec/models/option_spec.rb
+++ b/spec/models/option_spec.rb
@@ -3,6 +3,34 @@ require 'spec_helper'
 describe Option do
 
   it 'should create cleanly' do
-    create(:option, :name => 'Foo')
+    create(:option, name: 'Foo')
+  end
+
+  context 'with coordinates' do
+    it 'should require both latitude and longitude if either are present' do
+      # check each field with the other missing
+      %i(latitude longitude).each do |field|
+        option = build(:option, field => 0)
+        expect(option).to be_invalid
+      end
+
+      # check with the both present
+      option = create(:option, latitude: 0, longitude: 0)
+      expect(option).to be_valid
+    end
+
+    it 'should reject out-of-range latitudes' do
+      [-100, 100].each do |value|
+        option = build(:option, latitude: value, longitude: 0)
+        expect(option).to be_invalid
+      end
+    end
+
+    it 'should reject out-of-range longitudes' do
+      [-200, 200].each do |value|
+        option = build(:option, latitude: 0, longitude: value)
+        expect(option).to be_invalid
+      end
+    end
   end
 end

--- a/spec/models/option_spec.rb
+++ b/spec/models/option_spec.rb
@@ -33,4 +33,21 @@ describe Option do
       end
     end
   end
+
+  context 'has_coordinates?' do
+    it 'should return true if there are full coordinates' do
+      option = build(:option, latitude: 0, longitude: 0)
+      expect(option.has_coordinates?).to be_truthy
+    end
+
+    it 'should return true if there are partial coordinates' do
+      option = build(:option, latitude: 0)
+      expect(option.has_coordinates?).to be_truthy
+    end
+
+    it 'should return false if there are no coordinates' do
+      option = build(:option)
+      expect(option.has_coordinates?).to be_falsy
+    end
+  end
 end


### PR DESCRIPTION
Adds the ability to mark a geographic `OptionSet` with an `allow_coordinates` flag. Setting this flag on an option set exposes the ability to edit the `latitude` and `longitude` fields of an associated `Option`.

For answers that have coordinates, a small map is now shown in the `Response` "show" view.

This PR contains a first pass at implementing coordinate validation in the option editing modal dialog. Since the existing implementation did not show any error messages, I have not added that ability here either. All I do is disable the "Save" button as was done previously.