### PR TITLE
2672: Add coordinates to geographic option set export

### DIFF
--- a/app/controllers/option_sets_controller.rb
+++ b/app/controllers/option_sets_controller.rb
@@ -47,15 +47,7 @@ class OptionSetsController < ApplicationController
   end
 
   def export
-    @headers = [@option_set.class.human_attribute_name(:id)]
-    if @option_set.multi_level?
-      # use the level names as column headings for a multi-level option set
-      @headers.concat(@option_set.levels.map(&:name))
-    else
-      # the human-readable name for the Option.name attribute otherwise (e.g. "Name")
-      @headers << Option.human_attribute_name(:name)
-    end
-
+    @headers = @option_set.headers_for_export
     @rows = @option_set.arrange_as_rows
 
     render :xlsx => 'export', :filename => "#{@option_set.name}.xlsx"

--- a/app/controllers/option_sets_controller.rb
+++ b/app/controllers/option_sets_controller.rb
@@ -48,7 +48,13 @@ class OptionSetsController < ApplicationController
 
   def export
     @headers = [@option_set.class.human_attribute_name(:id)]
-    @headers.concat(@option_set.levels.map(&:name))
+    if @option_set.multi_level?
+      # use the level names as column headings for a multi-level option set
+      @headers.concat(@option_set.levels.map(&:name))
+    else
+      # the human-readable name for the Option.name attribute otherwise (e.g. "Name")
+      @headers << Option.human_attribute_name(:name)
+    end
 
     @rows = @option_set.arrange_as_rows
 

--- a/app/models/option.rb
+++ b/app/models/option.rb
@@ -59,6 +59,10 @@ class Option < ActiveRecord::Base
     self.class.where(canonical_name: canonical_name, mission_id: other_mission.try(:id)).first
   end
 
+  def coordinates
+    has_coordinates? && "#{latitude} #{longitude}"
+  end
+
   def as_json(options = {})
     if options[:for_option_set_form]
       super(only: [:id, :latitude, :longitude, :name_translations], methods: [:name, :set_names, :in_use?])

--- a/app/models/option_node.rb
+++ b/app/models/option_node.rb
@@ -225,12 +225,17 @@ class OptionNode < ActiveRecord::Base
     hash.each_with_object([]) do |(node,children),rows|
       path = parent_path + [node.option]
 
-      # output a row if we've hit a leaf node, using the option path to
-      # construct the list of cell values
       if children.empty?
-        rows << [node.id, *path.map(&:name)]
-      # otherwise recursively collect rows for the children
+        # output a row if we've hit a leaf node, using the option path to
+        # construct the list of cell values
+        row = [node.id, *path.map(&:name)]
+
+        # add the coordinates if the option set allows coordinates
+        row << node.option.coordinates if option_set.allow_coordinates?
+
+        rows << row
       else
+        # otherwise recursively collect rows for the children
         rows.concat(arrange_as_rows(children, path))
       end
     end

--- a/app/models/option_node.rb
+++ b/app/models/option_node.rb
@@ -225,19 +225,19 @@ class OptionNode < ActiveRecord::Base
     hash.each_with_object([]) do |(node,children),rows|
       path = parent_path + [node.option]
 
-      if children.empty?
-        # output a row if we've hit a leaf node, using the option path to
-        # construct the list of cell values
+      # output a row if we've hit a leaf node or a parent node with coordinates
+      if children.empty? || (option_set.allow_coordinates? && node.option.has_coordinates?)
+        # use the option path to construct the list of cell values
         row = [node.id, *path.map(&:name)]
 
         # add the coordinates if the option set allows coordinates
         row << node.option.coordinates if option_set.allow_coordinates?
 
         rows << row
-      else
-        # otherwise recursively collect rows for the children
-        rows.concat(arrange_as_rows(children, path))
       end
+
+      # recursively collect rows for the children
+      rows.concat(arrange_as_rows(children, path)) if children.present?
     end
   end
 

--- a/app/models/option_set.rb
+++ b/app/models/option_set.rb
@@ -237,6 +237,25 @@ class OptionSet < ActiveRecord::Base
     name_changed?
   end
 
+  # returns the localized headers to be used for export
+  def headers_for_export
+    [].tap do |headers|
+      headers << self.class.human_attribute_name(:id)
+
+      if multi_level?
+        # use the level names as column headings for a multi-level option set
+        headers.concat(levels.map(&:name))
+      else
+        # the human-readable name for the Option.name attribute otherwise (e.g. "Name")
+        headers << Option.human_attribute_name(:name)
+      end
+
+      if allow_coordinates?
+        headers << Option.human_attribute_name(:coordinates)
+      end
+    end
+  end
+
   def to_hash
     root_node.subtree.arrange_serializable(order: 'rank')
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -271,6 +271,7 @@ en:
         status: "Status"
       option:
         base: "" # this is a sort of hack to get error msg to display properly
+        coordinates: "Coordinates"
       option_set:
         allow_coordinates: "With Coordinates?"
         answers: "Answers"


### PR DESCRIPTION
Adds a "Coordinates" column to the `OptionSet` export if `allow_coordinates` is `true`. Also fixes the export of single-level option sets.