### PR TITLE
2338: Include geographic select_* answers on dashboard map

### DIFF
--- a/app/assets/javascripts/backbone/views/dashboard_map_view.js.coffee
+++ b/app/assets/javascripts/backbone/views/dashboard_map_view.js.coffee
@@ -16,7 +16,7 @@ class ELMO.Views.DashboardMapView extends Backbone.View
     })
 
     # keep track of which response ids we've rendered
-    @response_ids = {}
+    @distinct_answers = {}
 
     # add the markers and keep expanding the bounding rectangle
     bounds = new google.maps.LatLngBounds()
@@ -43,8 +43,8 @@ class ELMO.Views.DashboardMapView extends Backbone.View
   add_answer: (answer) ->
     [response_id, loc] = answer
 
-    # only add each response once
-    return if @response_ids[response_id]
+    # only add each response_id/lat/long once
+    return if @distinct_answers[answer]
 
     # get float values from string
     split = loc.split(' ')
@@ -64,8 +64,8 @@ class ELMO.Views.DashboardMapView extends Backbone.View
     # setup event listener to show info window
     google.maps.event.addListener(m, 'click', => this.show_info_window(m))
 
-    # keep track of the response id
-    @response_ids[response_id] = true
+    # keep track of the response_id/lat/long
+    @distinct_answers[answer] = true
 
     return m
 

--- a/app/assets/javascripts/backbone/views/dashboard_map_view.js.coffee
+++ b/app/assets/javascripts/backbone/views/dashboard_map_view.js.coffee
@@ -22,7 +22,7 @@ class ELMO.Views.DashboardMapView extends Backbone.View
     bounds = new google.maps.LatLngBounds()
     for l in @params.locations
       m = this.add_answer(l)
-      bounds.extend(m.position)
+      bounds.extend(m.position) if m
 
     # if there are stored bounds, use those to center map
     if this.load_bounds(@params.serialization_key)

--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -92,7 +92,7 @@ class WelcomeController < ApplicationController
         location_answers = Answer.location_answers_for_mission(current_mission, current_user)
 
         @location_answers_count = location_answers.total_entries
-        @location_answers = location_answers.pluck(:response_id, :value)
+        @location_answers = location_answers.map { |answer| [answer.response_id, answer.value] }
       end
 
       unless fragment_exist?(@cache_key + '/stat_blocks')


### PR DESCRIPTION
This PR updates the `Answer. location_answers_for_mission` method to include answers to `select_one` and `select_multiple` questions with geographic coordinates if the associated `OptionSet` is marked to allow coordinates.

In addition, this PR also includes the yet-to-be-merged changes from #91 since they're necessary to support geographic `select_*` options at all.