### PR TITLE
2397: Add reviewer notes field to Response

### DIFF
--- a/app/controllers/responses_controller.rb
+++ b/app/controllers/responses_controller.rb
@@ -240,7 +240,8 @@ class ResponsesController < ApplicationController
 
     def response_params
       if params[:response]
-        params.require(:response).permit(:form_id, :user_id, :incomplete, :reviewed).tap do |whitelisted|
+        reviewer_only = [:reviewed, :reviewer_notes] if @response.present? && can?(:review, @response)
+        params.require(:response).permit(:form_id, :user_id, :incomplete, *reviewer_only).tap do |whitelisted|
           whitelisted[:answers_attributes] = {}
 
           # The answers_attributes hash might look like {'2746' => { ... }, '2731' => { ... }, ... }

--- a/app/views/responses/form.html.erb
+++ b/app/views/responses/form.html.erb
@@ -36,7 +36,7 @@
     <%= f.field(:reviewed, :type => :check_box, :read_only => cannot?(:review, @response)) %>
 
     <%# only show the reviewer notes to reviewers %>
-    <%= f.field(:reviewer_notes, :type => :textarea) if can?(:review, @response) %>
+    <%= f.field(:reviewer_notes, :type => :textarea, :read_only_content => simple_format(@response.reviewer_notes)) if can?(:review, @response) %>
 
   <% end %>
 
@@ -59,7 +59,7 @@
 <% end %>
 
 <%= javascript_doc_ready do %>
-  $('textarea').each(function(){ CKEDITOR.replace(this.id); });
+  $('.answer_field textarea').each(function(){ CKEDITOR.replace(this.id); });
   ELMO.Response.init(<%=json({
     url: @response.new_record? ? possible_submitters_new_response_path : possible_submitters_response_path(@response)
   })%>);

--- a/app/views/responses/form.html.erb
+++ b/app/views/responses/form.html.erb
@@ -35,6 +35,9 @@
     <%# only show the reviewed checkbox as editable if the user can review the response %>
     <%= f.field(:reviewed, :type => :check_box, :read_only => cannot?(:review, @response)) %>
 
+    <%# only show the reviewer notes to reviewers %>
+    <%= f.field(:reviewer_notes, :type => :textarea) if can?(:review, @response) %>
+
   <% end %>
 
   <%# Answer sets %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -313,6 +313,7 @@ en:
         created_at: "Submission Time"
         form_id: "Form"
         reviewed: "Reviewed?"
+        reviewer_notes: "Reviewer Notes"
         source: "Source"
         user_id: "User/Team"
         incomplete: "Are there missing required answers?"

--- a/db/migrate/20150714205221_add_reviewer_notes_to_response.rb
+++ b/db/migrate/20150714205221_add_reviewer_notes_to_response.rb
@@ -1,0 +1,5 @@
+class AddReviewerNotesToResponse < ActiveRecord::Migration
+  def change
+    add_column :responses, :reviewer_notes, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150710212020) do
+ActiveRecord::Schema.define(version: 20150714205221) do
 
   create_table "answers", force: :cascade do |t|
     t.integer  "response_id",    limit: 4
@@ -328,12 +328,13 @@ ActiveRecord::Schema.define(version: 20150710212020) do
     t.integer  "user_id",           limit: 4
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.boolean  "reviewed",          limit: 1,   default: false
+    t.boolean  "reviewed",          limit: 1,     default: false
     t.string   "source",            limit: 255
     t.integer  "mission_id",        limit: 4
-    t.boolean  "incomplete",        limit: 1,   default: false, null: false
+    t.boolean  "incomplete",        limit: 1,     default: false, null: false
     t.datetime "checked_out_at"
     t.integer  "checked_out_by_id", limit: 4
+    t.text     "reviewer_notes",    limit: 65535
   end
 
   add_index "responses", ["checked_out_at"], name: "index_responses_on_checked_out_at", using: :btree

--- a/spec/features/responses_form_spec.rb
+++ b/spec/features/responses_form_spec.rb
@@ -125,6 +125,34 @@ feature 'responses form', js: true, sphinx: true do
     end
   end
 
+  describe 'reviewer notes' do
+
+    before do
+      @observer = create(:user, role_name: :observer)
+      @form = create(:form, question_types: %w(integer))
+      @notes = "Zero? (##{SecureRandom.hex})"
+      @response = create(:response, form: @form, answer_values: [0], reviewer_notes: @notes, user: @observer)
+    end
+
+    scenario 'should not be visible to normal users' do
+      login(@observer)
+      visit(response_path(@response, locale: 'en', mode: 'm', mission_name: get_mission.compact_name))
+      expect(page).not_to have_content(@notes)
+    end
+
+    scenario 'should be visible to admin' do
+      login(create(:user, admin: true))
+      visit(response_path(@response, locale: 'en', mode: 'm', mission_name: get_mission.compact_name))
+      expect(page).to have_content(@notes)
+    end
+
+    scenario 'should be visible to staffer' do
+      login(create(:user, role_name: :staffer))
+      visit(response_path(@response, locale: 'en', mode: 'm', mission_name: get_mission.compact_name))
+      expect(page).to have_content(@notes)
+    end
+  end
+
   def control_id(qing, suffix)
     "response_answers_attributes_#{qing.id}#{suffix}"
   end


### PR DESCRIPTION
Reviewer notes are only visible to those with `:review` permission (i.e. admins and mission users with a level of staffer or higher).