### PR TITLE
2441: Add form field on SMS guide for User/Team

### DIFF
--- a/app/views/forms/sms_guide.html.erb
+++ b/app/views/forms/sms_guide.html.erb
@@ -27,6 +27,15 @@
     <tr>
       <td class="rank"></td>
       <td class="pointer">
+        <em><%= Response.human_attribute_name(:user_id) %> </em>
+      </td>
+      <td class="answers">
+        <%= answer_space(" " * 7, :show_spc_glyph => false) %>
+      </td>
+    </tr>
+    <tr>
+      <td class="rank"></td>
+      <td class="pointer">
         <em><%= t("sms_form.guide.unique_code") %> </em>
       </td>
       <td class="answers">


### PR DESCRIPTION
This PR adds a space for writing down the "User/Team" on the printable SMS guide.

It uses 7 `.answer_space` slots to avoid a wrapping problem that appears to be happening on `datetime`, `text`, and `long_text` fields (which use 8).