### PR TITLE
Fix bug 2706: Invalid authenticity token for /submission

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -14,7 +14,7 @@ class ApplicationController < ActionController::Base
   # Makes sure authorization is performed in each controller. (CanCan method)
   check_authorization
 
-  protect_from_forgery with: :exception
+  protect_from_forgery with: :exception, unless: -> { request.format.json? || request.format.xml? }
 
   rescue_from Exception, :with => :notify_error
   rescue_from CanCan::AccessDenied, :with => :handle_access_denied

--- a/spec/controllers/odk_submission_spec.rb
+++ b/spec/controllers/odk_submission_spec.rb
@@ -5,6 +5,14 @@ describe 'odk submissions', type: :request do
 
   ODK_XML_FILE = 'odk_xml_file.xml'
 
+  before do
+    allow_forgery_protection true
+  end
+
+  after do
+    allow_forgery_protection false
+  end
+
   context 'to regular mission' do
 
     before do
@@ -185,5 +193,9 @@ describe 'odk submissions', type: :request do
   def submission_path(mission = nil)
     mission ||= get_mission
     "/m/#{mission.compact_name}/submission"
+  end
+
+  def allow_forgery_protection(allow)
+    ActionController::Base.allow_forgery_protection = allow
   end
 end


### PR DESCRIPTION
Just added a conditional to `protect_from_forgery` to not do it if the request is not coming from the rails app (a json or xml format).

Also enabled the `protect_from_forgery` on the spec to mimic the application real behavior.