### PR TITLE
2674: Fix question key value not being set on save.

### DIFF
--- a/app/controllers/concerns/question_formable.rb
+++ b/app/controllers/concerns/question_formable.rb
@@ -10,11 +10,6 @@ module QuestionFormable
     @questioning = Questioning.accessible_by(current_ability).new(params)
     @questioning.build_question if @questioning.question.nil?
 
-    # override the associated question attributes with those mandated by the authorization system
-    Question.accessible_by(current_ability).new.attributes.each_pair do |k,v|
-      @questioning.question.send("#{k}=", v) unless v.nil?
-    end
-
     # set the mission of the question and questioning to the current mission
     # to ensure proper permission handling
     @questioning.mission = @questioning.question.mission = current_mission


### PR DESCRIPTION
The `key` attribute was being overwritten on the `init_qing` method. We decided to remove that part of the code because it was only being useful to set the `mission_id` (and that is being done on the lines below it).