### PR TITLE
2275 fix whitelist users on protected form

### DIFF
--- a/app/controllers/forms_controller.rb
+++ b/app/controllers/forms_controller.rb
@@ -112,7 +112,9 @@ class FormsController < ApplicationController
   end
 
   def create
+    set_api_users
     @form.is_standard = true if current_mode == 'admin'
+
     if @form.save
       @form.create_root_group!(mission: @form.mission, form: @form)
       @form.save!
@@ -126,7 +128,7 @@ class FormsController < ApplicationController
   def update
     begin
       Form.transaction do
-        update_api_users
+        set_api_users
         # save basic attribs
         @form.assign_attributes(form_params)
 
@@ -233,11 +235,13 @@ class FormsController < ApplicationController
 
   private
 
-    def update_api_users
+    def set_api_users
       return unless params[:form][:access_level] == 'protected'
-      @form.whitelist_users.destroy
+
+      @form.whitelist_users.destroy_all if action_name == 'update'
+
       (params[:whitelist_users] || []).each do |api_user|
-        @form.whitelist_users.create(user_id: api_user)
+        @form.whitelist_users.new(user_id: api_user)
       end
     end
 

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -5,7 +5,7 @@ class Form < ActiveRecord::Base
 
   has_many(:responses, :inverse_of => :form)
   has_many(:versions, :class_name => "FormVersion", :inverse_of => :form, :dependent => :destroy)
-  has_many(:whitelist_users, :as => :whitelistable, class_name: "Whitelist")
+  has_many(:whitelist_users, :as => :whitelistable, class_name: "Whitelist", dependent: :destroy)
   has_many(:standard_form_reports, class_name: 'Report::StandardFormReport', dependent: :destroy)
 
   # while a form has many versions, this is a reference to the most up-to-date one


### PR DESCRIPTION
The problem reported was on form creation, where it wasn't saving the users on protected forms. But there was also a bug on edit. It wasn't removing whitelist_users because of a call on destroy instead
of destroy_all.

Also added dependent: :destroy on whitelist_users to avoid database orphans when we deleted a form.