### PR TITLE
2280: Fix html showing on search results.

### DIFF
--- a/config/thinking_sphinx.yml.example
+++ b/config/thinking_sphinx.yml.example
@@ -3,9 +3,12 @@
 development:
   mysql41: 9306
   max_matches: 1000000
+  html_strip: true
 test:
   mysql41: 9307 # should be on different port than development
   max_matches: 1000000
+  html_strip: true
 production:
   mysql41: 9306
   max_matches: 1000000
+  html_strip: true


### PR DESCRIPTION
It was just missing a configuration on the thinking_sphinx.yml.
For a while, Thinking Sphinx auto-escaped excerpts.However, Sphinx
itself can remove HTML entities for indexing and excerpts, which
is a better way to approach this.