### PR TITLE
2783: Fix <br> tag appearing on sms index.

### DIFF
--- a/app/helpers/sms_helper.rb
+++ b/app/helpers/sms_helper.rb
@@ -11,14 +11,14 @@ module SmsHelper
     when "time" then
       if sms.sent_at <= sms.created_at - 1.minute
         time_diff = time_diff(sms.sent_at, sms.created_at)
-        t('sms.timestamp_with_diff', time: l(sms.created_at), time_diff: time_diff)
+        t('sms.timestamp_with_diff_html', time: l(sms.created_at), time_diff: time_diff)
       else
         l(sms.created_at)
       end
     when "to" then
       recips = safe_join(sms.recipient_hashes(max: MAX_RECIPS_TO_SHOW).map { |r| user_with_phone(r[:user], r[:phone]) }, '<br/>'.html_safe)
       extra_recipients = sms.recipient_count - MAX_RECIPS_TO_SHOW
-      recips << (extra_recipients > 0 ? t('sms.extra_recipients', count: extra_recipients).html_safe : '')
+      recips << (extra_recipients > 0 ? t('sms.extra_recipients_html', count: extra_recipients) : '')
       recips
     when "from" then
       user_with_phone(sms.sender, sms.from)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1638,10 +1638,10 @@ en:
       twilio: "Twilio Settings"
 
   sms:
-    extra_recipients: "<br/>... and %{count} more"
+    extra_recipients_html: "<br/>... and %{count} more"
     no_valid_adapter: "There is no valid outgoing SMS adapter. Please check the settings."
     outgoing_provider: "Outgoing SMS Provider"
-    timestamp_with_diff: "%{time}<br/>(sent %{time_diff} earlier)"
+    timestamp_with_diff_html: "%{time}<br/>(sent %{time_diff} earlier)"
 
   sms_console:
     back_to_forms: "Back to Forms"


### PR DESCRIPTION
The problem is that the string wasn't being tagged as `html_safe`. To avoid these kind of mistakes of just forgetting to call it, we can change the I18n key to end with "_html" and that automatically sets it as `html_safe`.