### PR TITLE
2503: Add Search::Qualifier support for multi columns.

### DIFF
--- a/app/models/search/qualifier.rb
+++ b/app/models/search/qualifier.rb
@@ -94,4 +94,8 @@ class Search::Qualifier
   def regexp?
     pattern.present?
   end
+
+  def has_more_than_one_column?
+    col.is_a? Array
+  end
 end

--- a/app/models/sms/message.rb
+++ b/app/models/sms/message.rb
@@ -35,7 +35,7 @@ class Sms::Message < ActiveRecord::Base
       Search::Qualifier.new(name: "datetime", col: "sms_messages.created_at", type: :scale),
       Search::Qualifier.new(name: "username", col: "users.login", type: :text, assoc: user_assoc, default: true),
       Search::Qualifier.new(name: "name", col: "users.name", type: :text, assoc: user_assoc, default: true),
-      Search::Qualifier.new(name: "number", col: "sms_messages.to", type: :text, default: true)
+      Search::Qualifier.new(name: "number", col: ["sms_messages.to", "sms_messages.from"], type: :text, default: true)
     ]
   end
 

--- a/spec/models/search/search_spec.rb
+++ b/spec/models/search/search_spec.rb
@@ -39,7 +39,11 @@ describe Search::Search do
 
   INDEXED = [
     Search::Qualifier.new(name: "text", col: "tbl.id", type: :indexed),
-    Search::Qualifier.new(name: "source", col: "t.source")
+    Search::Qualifier.new(name: "source", col: "t.source"),
+
+    # Qualifiers with multiple columns
+    Search::Qualifier.new(name: "number", col: ["msg.to", "msg.from"], type: :text),
+    Search::Qualifier.new(name: "date", col: ["msg.created_at", "msg.updated_at"], type: :scale)
   ]
 
   it "no defaults" do
@@ -283,6 +287,11 @@ describe Search::Search do
 
   it "search with multiple default qualifiers should work" do
     assert_search(str: 'test', sql: "((t1.f2 = 'test') OR (t1.f3 = 'test'))", qualifiers: MULTIPLE_DEFAULTS)
+  end
+
+  it "supports multiple columns to generate a sql" do
+    assert_search(str: 'number:987', sql: "((msg.to LIKE '%987%') OR (msg.from LIKE '%987%'))", qualifiers: INDEXED)
+    assert_search(str: 'date:date', sql: "((msg.created_at = 'date') OR (msg.updated_at = 'date'))", qualifiers: INDEXED)
   end
 
   private


### PR DESCRIPTION
Fixed bug of number:123 not searching sender of SMS. It turns out it was searching only on the .to column and not on the .from table also. 

Had to add support to generate a sql from multiple columns.