### PR TITLE
2676: Fix required asterisk display on SMS guide.

### DIFF
--- a/app/assets/stylesheets/all/elmo_forms.css.scss
+++ b/app/assets/stylesheets/all/elmo_forms.css.scss
@@ -33,7 +33,7 @@ div.form_field {
     margin-left: 0;
   }
 
-  div.reqd_sym {
+  div.reqd-sym {
     display: inline;
     font-weight: bold;
     color: $orange;

--- a/app/assets/stylesheets/all/sms_guide.css.scss
+++ b/app/assets/stylesheets/all/sms_guide.css.scss
@@ -38,7 +38,8 @@ div.sms_guide {
     font-weight: bold;
   }
 
-  td.question .reqd_sym {
+  td.question .reqd-sym {
+    display: inline-block;
     color: black;
     font-size: 18px;
   }

--- a/app/assets/stylesheets/print/form.css.scss
+++ b/app/assets/stylesheets/print/form.css.scss
@@ -64,7 +64,7 @@
   div#reqd_message {
     float: right;
   }
-  div.reqd_sym {
+  div.reqd-sym {
     display: inline-block;
     font-weight: bold;
     font-size: 125%;

--- a/app/helpers/elmo_form_helper.rb
+++ b/app/helpers/elmo_form_helper.rb
@@ -41,7 +41,7 @@ module ElmoFormHelper
 
   # renders the standard 'required' symbol, which is an asterisk
   def reqd_sym
-    content_tag(:div, '*', :class => 'reqd_sym')
+    content_tag(:div, '*', :class => 'reqd-sym')
   end
 
   private


### PR DESCRIPTION
It was just missing a `display: inline-block` on it's css. Also refactored class name to use dashes instead of underscore.