### PR TITLE
2716: Fix questions numbering on sms guide.

### DIFF
--- a/app/views/forms/sms_guide.html.erb
+++ b/app/views/forms/sms_guide.html.erb
@@ -42,7 +42,7 @@
     <%# loop over each question %>
     <% @form.smsable_questionings.each do |qing| %>
       <tr>
-        <td class="rank"><%= qing.rank %>.</td>
+        <td class="rank"><%= qing.full_dotted_rank %>.</td>
         <td class="question">
           <%= qing.question.name %>
           <%= reqd_sym if qing.required? %>


### PR DESCRIPTION
For questions that were nested on a group, the ranks were being shown without the group index. Just created a helper to calculate and format that.