### PR TITLE
2680 fix option set import/export i18n

### DIFF
--- a/app/models/concerns/translatable.rb
+++ b/app/models/concerns/translatable.rb
@@ -15,7 +15,7 @@ module Translatable
       # save the list of translated fields
       class_variable_set('@@translated_fields', args)
 
-      # set up the _tranlsations fields to serialize
+      # set up the _translations fields to serialize
       translated_fields.each do |f|
         ancestors.include?(ActiveRecord::Base) ? (serialize "#{f}_translations", JSON) : (attr_accessor "#{f}_translations")
       end

--- a/app/models/option_node.rb
+++ b/app/models/option_node.rb
@@ -222,7 +222,7 @@ class OptionNode < ActiveRecord::Base
 
   # arranges option descendant nodes into rows for export.
   # rows are created for leaf nodes only and contain the node id and the
-  # localized option names in the current locale.
+  # localized option names in the mission preferred locale.
   def arrange_as_rows(hash = nil, parent_path = [])
     hash = arrange_with_options(eager_load_option_assocs: false) if hash.nil?
 
@@ -232,7 +232,7 @@ class OptionNode < ActiveRecord::Base
       # output a row if we've hit a leaf node or a parent node with coordinates
       if children.empty? || (option_set.allow_coordinates? && node.option.has_coordinates?)
         # use the option path to construct the list of cell values
-        row = [node.id, *path.map(&:name)]
+        row = [node.id, *preferred_name_translations(path)]
 
         # add the coordinates if the option set allows coordinates
         row << node.option.coordinates if option_set.allow_coordinates?
@@ -243,6 +243,10 @@ class OptionNode < ActiveRecord::Base
       # recursively collect rows for the children
       rows.concat(arrange_as_rows(children, path)) if children.present?
     end
+  end
+
+  def preferred_name_translations(path)
+    path.map{ |p| p.name(configatron.preferred_locale.to_s) }
   end
 
   # Returns the total number of options omitted from the JSON serialization.

--- a/app/models/option_set_import.rb
+++ b/app/models/option_set_import.rb
@@ -132,11 +132,14 @@ class OptionSetImport
       headers = sheet.row(1)
       headers = headers[0...headers.index(nil)] if headers.any?(&:nil?)
 
+      # Get special columns i18n values
+      id_header = "Id"
+      coordinates_header = I18n.t('activerecord.attributes.option.coordinates')
+
       # Find any special columns
       special_columns = {}
       headers.each_with_index do |h,i|
-        # TODO: i18n
-        if ["Id", "Coordinates"].include?(h)
+        if [id_header, coordinates_header].include?(h)
           special_columns[i] = h.downcase.to_sym
         end
       end

--- a/app/models/option_set_import.rb
+++ b/app/models/option_set_import.rb
@@ -72,7 +72,7 @@ class OptionSetImport
 
           if cell.present?
             # Create the option.
-            attribs = { mission: mission, name: cell }
+            attribs = { mission: mission, name_locale_key => cell }
             # TODO: nicer check for leaf nodes
             attribs.merge!(leaf_attribs) if row[c+1...headers.size].all?(&:blank?)
             option = Option.create(attribs)
@@ -202,4 +202,7 @@ class OptionSetImport
       !row[row.index(nil)..-1].all?(&:nil?)
     end
 
+    def name_locale_key
+      :"name_#{configatron.preferred_locale}"
+    end
 end

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -104,6 +104,9 @@ class Setting < ActiveRecord::Base
       nil
     end
 
+    #set the preferred locale for the mission
+    hsh[:preferred_locale] = preferred_locales.first
+
     # set system timezone
     Time.zone = timezone
 

--- a/spec/models/option_set_import_spec.rb
+++ b/spec/models/option_set_import_spec.rb
@@ -3,6 +3,10 @@ require 'spec_helper'
 describe OptionSetImport do
   let(:mission) { get_mission }
 
+  before do
+    configatron.preferred_locale = :en
+  end
+
   it 'should be able to import a simple option set' do
     name = "Simple"
 


### PR DESCRIPTION
Fix option set import preferred_locale and also export.
Import wasn't using the ones from configatron and export was just using the name for the option, not one
of it's translations. Now we are getting the translation for the first language preferred.