### PR TITLE
2819: Fix tags not being rendered properly on form list.

### DIFF
--- a/app/helpers/questions_helper.rb
+++ b/app/helpers/questions_helper.rb
@@ -44,7 +44,7 @@ module QuestionsHelper
     when "actions" then table_action_links(q)
     when "name"
       if params[:controller] == 'forms'
-        q.name + render_tags(q.sorted_tags)
+        html_escape(q.name) << render_tags(q.sorted_tags)
       else
         link_to(q.name, q) + render_tags(q.sorted_tags, clickable: true)
       end


### PR DESCRIPTION
It wasn't being marked as html safe. We need to guarantee that the tag.name is being properly escaped
before doing this...