### PR TITLE
CSS for right-to-left support

### DIFF
--- a/app/assets/stylesheets/all/rtl.css.scss
+++ b/app/assets/stylesheets/all/rtl.css.scss
@@ -50,4 +50,9 @@ html[dir="rtl"] {
     margin-right: 0;
     margin-left: 3px;
   }
+
+  #userinfo a.login {
+    margin-right: 0;
+    margin-left: 22px;
+  }
 }

--- a/app/assets/stylesheets/all/rtl.css.scss
+++ b/app/assets/stylesheets/all/rtl.css.scss
@@ -1,0 +1,53 @@
+html[dir="rtl"] {
+  #userinfo {
+    float: left;
+
+    .icon-btn {
+      float: right;
+    }
+  }
+
+  .navbar-header {
+    float: right;
+  }
+
+  .navbar-nav {
+    float: right;
+
+    li {
+      float: right;
+
+      i {
+        margin-left: 5px;
+        margin-right: 0;
+      }
+    }
+  }
+
+  th {
+    text-align: right;
+  }
+
+  div.form_field {
+    label.main {
+      float: right;
+    }
+
+    div.control {
+      margin-left: 0;
+      margin-right: 200px;
+    }
+  }
+
+  .search-footer {
+    & > a {
+      float: right;
+      margin-top: 2px;
+    }
+  }
+
+  div.top-action-links a i {
+    margin-right: 0;
+    margin-left: 3px;
+  }
+}


### PR DESCRIPTION
most elements in the UI look OK in a right-to-left language, but a few appear in the wrong order. Here's a SCSS file which flips the remaining lists and padding inside \<html dir="rtl"\>