### PR TITLE
2839 fix inconsistent qing count

### DIFF
--- a/app/models/replication/obj_proxy.rb
+++ b/app/models/replication/obj_proxy.rb
@@ -192,7 +192,8 @@ class Replication::ObjProxy
 
     def get_copy_id(target_class, orig_id)
       if target_class.standardizable?
-        target_class.where(mission_id: replicator.target_mission_id, original_id: orig_id).pluck(:id).first
+        # Find the appropriate copy in the replicator history
+        replicator.history.get_copy(target_class, orig_id).try(:id)
       elsif reuse_col = target_class.replicable_opts[:reuse_if_match]
         orig_reuse_val = target_class.where(id: orig_id).pluck(reuse_col).first
         target_class.where(mission_id: replicator.target_mission_id, reuse_col => orig_reuse_val).pluck(:id).first

--- a/db/migrate/20150817204307_add_nullify_to_original_id_fks.rb
+++ b/db/migrate/20150817204307_add_nullify_to_original_id_fks.rb
@@ -1,0 +1,18 @@
+class AddNullifyToOriginalIdFks < ActiveRecord::Migration
+  def up
+    remove_foreign_key "forms", column: "original_id", name: "forms_standard_id_fk" rescue 'No fk to remove...'
+    add_foreign_key "forms", "forms", column: "original_id", name: "forms_standard_id_fk", on_delete: :nullify
+
+    remove_foreign_key "option_sets", column: "original_id", name: "option_sets_standard_id_fk" rescue 'No fk to remove...'
+    add_foreign_key "option_sets", "option_sets", column: "original_id", name: "option_sets_standard_id_fk", on_delete: :nullify
+
+    remove_foreign_key "questions", column: "original_id", name: "questions_standard_id_fk" rescue 'No fk to remove...'
+    add_foreign_key "questions", "questions", column: "original_id", name: "questions_standard_id_fk", on_delete: :nullify
+  end
+
+  def down
+    remove_foreign_key "forms", column: "original_id", name: "forms_standard_id_fk"
+    remove_foreign_key "option_sets", column: "original_id", name: "option_sets_standard_id_fk"
+    remove_foreign_key "questions", column: "original_id", name: "questions_standard_id_fk"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150806165057) do
+ActiveRecord::Schema.define(version: 20150817204307) do
   create_table "answers", force: :cascade do |t|
     t.datetime "created_at"
     t.date "date_value"
@@ -484,7 +484,7 @@ ActiveRecord::Schema.define(version: 20150806165057) do
   add_foreign_key "form_items", "questions", name: "questionings_question_id_fk"
   add_foreign_key "form_versions", "forms", name: "form_versions_form_id_fk"
   add_foreign_key "forms", "form_versions", column: "current_version_id", name: "forms_current_version_id_fk", on_delete: :nullify
-  add_foreign_key "forms", "forms", column: "original_id", name: "forms_standard_id_fk"
+  add_foreign_key "forms", "forms", column: "original_id", name: "forms_standard_id_fk", on_delete: :nullify
   add_foreign_key "forms", "missions", name: "forms_mission_id_fk"
   add_foreign_key "groups", "missions", name: "groups_mission_id_fk"
   add_foreign_key "operations", "users", column: "creator_id"
@@ -493,11 +493,11 @@ ActiveRecord::Schema.define(version: 20150806165057) do
   add_foreign_key "option_nodes", "options", name: "option_nodes_option_id_fk"
   add_foreign_key "option_sets", "missions", name: "option_sets_mission_id_fk"
   add_foreign_key "option_sets", "option_nodes", column: "root_node_id", name: "option_sets_root_node_id_fk"
-  add_foreign_key "option_sets", "option_sets", column: "original_id", name: "option_sets_standard_id_fk"
+  add_foreign_key "option_sets", "option_sets", column: "original_id", name: "option_sets_standard_id_fk", on_delete: :nullify
   add_foreign_key "options", "missions", name: "options_mission_id_fk"
   add_foreign_key "questions", "missions", name: "questions_mission_id_fk"
   add_foreign_key "questions", "option_sets", name: "questions_option_set_id_fk"
-  add_foreign_key "questions", "questions", column: "original_id", name: "questions_standard_id_fk"
+  add_foreign_key "questions", "questions", column: "original_id", name: "questions_standard_id_fk", on_delete: :nullify
   add_foreign_key "report_calculations", "questions", column: "question1_id", name: "report_calculations_question1_id_fk"
   add_foreign_key "report_calculations", "report_reports", name: "report_calculations_report_report_id_fk"
   add_foreign_key "report_option_set_choices", "option_sets", name: "report_option_set_choices_option_set_id_fk"

--- a/spec/models/replication/form_replication_spec.rb
+++ b/spec/models/replication/form_replication_spec.rb
@@ -46,6 +46,17 @@ describe Form do
         expect(@copy1.c[0].question).to eq @copy2.c[0].question
         expect(@copy1.c[0].question.option_set).to eq @copy2.c[0].question.option_set
       end
+
+      context 'when using eager loaded values from form items query' do
+        it 'keeps the questioning count consistent' do
+          std_qing_count = form_items_qing_count(@std)
+          copy1_qing_count = form_items_qing_count(@copy1)
+          copy2_qing_count = form_items_qing_count(@copy2)
+
+          expect(std_qing_count).to eq copy1_qing_count
+          expect(std_qing_count).to eq copy2_qing_count
+        end
+      end
     end
 
     context 'with a condition referencing an option' do
@@ -201,5 +212,9 @@ describe Form do
         expect(@copy.standard_copy?).to be_falsy
       end
     end
+  end
+
+  def form_items_qing_count(form_id)
+    FormItem.where(form_id: form_id, type: 'Questioning').count
   end
 end


### PR DESCRIPTION
The bug is related to duplicating a form more than once. After the first copy, each time you duplicate the original form again, it adds questionings copies to the first copy (on the form_items table) and not on the new copy.

Also added a nullify on original_id fk constraint, because user couldn't delete a form that was copied.