### PR TITLE
Add client_max_body_size to allow bigger file uploads.

### DIFF
--- a/docs/nginx.conf
+++ b/docs/nginx.conf
@@ -39,6 +39,8 @@ http {
     passenger_enabled on;
     rails_env production;
 
+    client_max_body_size 10M;
+
     # Certificate
     ssl on;
     ssl_certificate ssl/ssl.crt;


### PR DESCRIPTION
nginx default is to allow only files with 1M.