### PR TITLE
3074: Improve non observers show on StandardFormReport.

### DIFF
--- a/app/assets/javascripts/templates/report/form_summary_display.jst.ejs
+++ b/app/assets/javascripts/templates/report/form_summary_display.jst.ejs
@@ -14,7 +14,7 @@
   </tr>
   <tr>
     <td><%= I18n.t('report/report.missing_observers') %></td>
-    <td><%= report.observers_without_responses.map(function(obs){ return obs.name; }).join(', ') %></td>
+    <td><%= report.observers_without_responses %></td>
   </tr>
 </table>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1214,6 +1214,7 @@ en:
     loading_report: "Loading Report..."
     questions_with_option_sets: "Questions with these option sets"
     missing_observers: "Non-reporting Observers"
+    missing_observers_total_count: "%{user_count} in total"
     mission: "Mission"
     no_match: "No matching data were found."
     question_selection: "Select Questions"
@@ -1242,6 +1243,7 @@ en:
     which_calculation: "Which calculation (if any) would you like to apply?"
     which_forms: "Which forms are you interested in?"
     which_questions: "Which question(s) would you like to include?"
+    zero_missing_observers: "None"
     bar_styles:
       side_by_side: "Side By Side"
       stacked: "Stacked"

--- a/db/migrate/20150924200325_add_user_form_composite_index_on_responses.rb
+++ b/db/migrate/20150924200325_add_user_form_composite_index_on_responses.rb
@@ -1,0 +1,5 @@
+class AddUserFormCompositeIndexOnResponses < ActiveRecord::Migration
+  def change
+    add_index :responses, [:user_id, :form_id]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150904133758) do
+ActiveRecord::Schema.define(version: 20150924200325) do
   create_table "answers", force: :cascade do |t|
     t.datetime "created_at"
     t.date "date_value"
@@ -344,6 +344,7 @@ ActiveRecord::Schema.define(version: 20150904133758) do
   add_index "responses", ["mission_id"], name: "responses_mission_id_fk", using: :btree
   add_index "responses", ["reviewed"], name: "index_responses_on_reviewed", using: :btree
   add_index "responses", ["updated_at"], name: "index_responses_on_updated_at", using: :btree
+  add_index "responses", ["user_id", "form_id"], name: "index_responses_on_user_id_and_form_id", using: :btree
   add_index "responses", ["user_id"], name: "responses_user_id_fk", using: :btree
 
   create_table "sessions", force: :cascade do |t|

--- a/spec/models/report/standard_form_report_spec.rb
+++ b/spec/models/report/standard_form_report_spec.rb
@@ -77,7 +77,8 @@ describe Report::StandardFormReport do
 
     it "should return non-submitting observers" do
       # make observers
-      observers = %w(bob jojo cass sal).map{|n| create(:user, :login => n, :role_name => :observer)}
+      observers = %w(bob jojo cass sal).map{|n| create(:user, login: n, role_name: :observer,
+        name: n.capitalize)}
 
       # make decoy coord and admin users
       coord = create(:user, :role_name => :coordinator)
@@ -87,9 +88,16 @@ describe Report::StandardFormReport do
       @form = create(:form)
       observers[0...2].each{|o| create(:response, :form => @form, :user => o)}
 
-      # run report and check missing observers
       build_and_run_report
-      expect(@report.users_without_responses(:role => :observer).map(&:login).sort).to eq(%w(cass sal))
+
+      #check missing observers
+      missing_observers = @report.users_without_responses(role: :observer, limit: 10)[:users]
+      expect(missing_observers.map(&:login).sort).to eq(%w(cass sal))
+      expect(@report.observers_without_responses).to eq('Cass, Sal')
+
+      #Change constant size to check mission observers summarization
+      stub_const("Report::StandardFormReport::MISSING_OBSERVERS_SIZE_LIMIT", 1)
+      expect(@report.observers_without_responses).to eq('Cass, ... (2 in total)')
     end
 
     it "empty? should be false if responses" do


### PR DESCRIPTION
The system was fetching all users to show them on the form. This was
making the system extremely slow when it had a lot of users on the
database. I created one query to fetch the users limiting how many
we are getting and used SQL_CALC_FOUND_ROWS to get the total count
without hitting the db again.