### PR TITLE
3289: Limit reponses on ResponseTallyReport.

### DIFF
--- a/app/assets/javascripts/views/report/table_display.js
+++ b/app/assets/javascripts/views/report/table_display.js
@@ -213,12 +213,18 @@
   }
 
   klass.prototype.i18n_total_rows_label = function(data){
-    if (this.report.attribs.type.match(/ListReport/)) {
+    if (this.report.attribs.type.match(/ListReport/) ||
+        this.is_response_tally_report(this.report)) {
       return I18n.t("report/report.total_rows_showing",
         {count: data.rows.length,total_count: data.total_row_count})
     } else {
       return I18n.t("report/report.total_rows", {count: data.rows.length})
     }
+  }
+
+  klass.prototype.is_response_tally_report = function(report){
+    return (report.attribs.type.match(/Report::TallyReport/) &&
+      report.attribs.tally_type.match(/Response/))
   }
 
 }(ELMO.Report));

--- a/app/models/concerns/report/gridable.rb
+++ b/app/models/concerns/report/gridable.rb
@@ -2,6 +2,8 @@
 module Report::Gridable
   extend ActiveSupport::Concern
 
+  RESPONSES_QUANTITY_LIMIT = 1000
+
   included do
     attr_reader :header_set, :data, :totals, :query
   end
@@ -23,11 +25,11 @@ module Report::Gridable
 
     @data = Report::Data.new(blank_data_table(@db_result))
 
-    # If it's a ListReport, we need to get the total row count, because we are limiting
-    # how many we are showing
-    if self.is_a? Report::ListReport
-      #Get the total row count from SQL_CALC_FOUND_ROWS on ListReport prep_query
-      total_row_count = ActiveRecord::Base.connection.execute('SELECT FOUND_ROWS();').entries[0].first
+    # If it's a ListReport or ResponseTallyReport, we need to get the total row count
+    # because we are limiting how many we are showing
+    if self.is_a?(Report::ListReport) || self.is_a?(Report::ResponseTallyReport)
+      #Get the total row count from SQL_CALC_FOUND_ROWS on the report prep_query
+      total_row_count = ActiveRecord::Base.connection.execute('SELECT FOUND_ROWS()').entries[0].first
       @data.total_row_count = total_row_count
     end
 

--- a/app/models/report/list_report.rb
+++ b/app/models/report/list_report.rb
@@ -1,8 +1,6 @@
 class Report::ListReport < Report::Report
   include Report::Gridable
 
-  RESPONSES_QUANTITY_LIMIT = 1000
-
   def as_json(options = {})
     h = super(options)
     h[:calculations_attributes] = calculations

--- a/app/models/report/response_tally_report.rb
+++ b/app/models/report/response_tally_report.rb
@@ -12,13 +12,15 @@ class Report::ResponseTallyReport < Report::TallyReport
       joins = []
 
       # add tally to select
-      rel = rel.select("COUNT(responses.id) AS tally")
+      rel = rel.select("SQL_CALC_FOUND_ROWS COUNT(responses.id) AS tally")
 
       # add filter
       rel = apply_filter(rel)
 
       # add groupings
       rel = apply_groupings(rel)
+
+      rel = rel.limit(RESPONSES_QUANTITY_LIMIT)
     end
 
     # applys both groupings


### PR DESCRIPTION
This was done to avoid slowness when rendering a lot of table rows and on database fetching.