### PR TITLE
3014: Updates backbone view to prevent double form submission

### DIFF
--- a/app/assets/javascripts/backbone/views/group_modal_view.js.coffee
+++ b/app/assets/javascripts/backbone/views/group_modal_view.js.coffee
@@ -25,7 +25,9 @@ class ELMO.Views.GroupModalView extends Backbone.View
     return this.form_data
 
   keypress: (e) ->
-    this.save() if e.keyCode == 13 # Enter
+    if e.keyCode == 13 # Enter
+      e.preventDefault()
+      this.save()
 
   save: ->
     ELMO.app.loading(true)
@@ -41,7 +43,7 @@ class ELMO.Views.GroupModalView extends Backbone.View
     @$el.modal('show')
 
   focus_first_box: ->
-    @$('input[type=text]')[0].focus();
+    @$('input[type=text]')[0].focus()
 
   hide: ->
     @$el.modal('hide')


### PR DESCRIPTION
Submitting the from with "enter" was both submitting the HTML form and triggering the save call in backbone causing the duplicate groups and the weird redirect.