### PR TITLE
3390: Fixes option set export bug

### DIFF
--- a/app/models/option_set.rb
+++ b/app/models/option_set.rb
@@ -293,6 +293,23 @@ class OptionSet < ActiveRecord::Base
     end
   end
 
+  def worksheet_name
+    name = self.name
+    name = name.truncate(31) if self.name.size > 31
+    name = name.gsub(
+      /[\[\]\*\\?\:\/]/, {
+        '[' => '(',
+        ']' => ')',
+        '*' => '∗',
+        '?' => '',
+        ':' => '-',
+        '\\' => '-',
+        '/' => '-'
+      }
+    )
+    name
+  end
+
   # Returns a string representation, including options, for the default locale.
   def to_s
     "Name: #{name}\nOptions:\n#{root_node.to_s_indented}"

--- a/app/views/option_sets/export.xlsx.axlsx
+++ b/app/views/option_sets/export.xlsx.axlsx
@@ -6,7 +6,7 @@ xlsx_package.workbook.tap do |wb|
 
   locale = @option_set.mission.setting.preferred_locales.first || :en
   I18n.with_locale(locale) do
-    wb.add_worksheet(name: @option_set.name) do |sheet|
+    wb.add_worksheet(name: @option_set.worksheet_name) do |sheet|
       sheet.add_row(@headers, style: header_style)
 
       @rows.each do |row|

--- a/spec/models/option_set_spec.rb
+++ b/spec/models/option_set_spec.rb
@@ -75,4 +75,17 @@ describe OptionSet do
       expect(set.levels[1].name).to eq 'Species'
     end
   end
+
+  describe 'worksheet_name' do
+    it 'should return the original name if valid' do
+      set = create(:option_set)
+      expect(set.worksheet_name).to eq set.name
+    end
+
+    it 'should return a replaced name if invalid' do
+      set = create(:option_set, name: 'My Options?: ~*[Yes/No:No\Yes]*~')
+      expect(set.worksheet_name.size).to be <= 31
+      expect(set.worksheet_name).to eq 'My Options- ~∗(Yes-No-No-Ye...'
+    end
+  end
 end


### PR DESCRIPTION
Fixes bug where option set names longer than 31 characters or with special characters would cause the export to fail.

* Adds `worksheet_name` method to OptionSet model
* Updates export view to use `worksheet_name` for the export