### PR TITLE
3391: Fixes bug updating multilevel option sets

### DIFF
--- a/app/controllers/concerns/parameters.rb
+++ b/app/controllers/concerns/parameters.rb
@@ -20,11 +20,13 @@ module Parameters
   def permit_children(params, options)
     key = options[:key]
     permitted = options[:permitted]
-    params[key].map do |child|
-      if child[key].present? && child[key] != 'NONE'
-        permitted + [{ key => permit_children(child, options) }]
-      else
-        permitted + [key]
+    if params[key].present?
+      params[key].map do |child|
+        if child[key].present? && child[key] != 'NONE'
+          permitted + [{ key => permit_children(child, options) }]
+        else
+          permitted + [key]
+        end
       end
     end
   end


### PR DESCRIPTION
Updates to multi-level option sets with read-only levels tried to permit child attributes that weren't present. This checks to make sure that the key for children to permit is present before continuing.

* Updates `permit_children` method in parameters concern with check for key presence