### PR TITLE
3007: Question groups are SMS-Able

### DIFF
--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -175,9 +175,10 @@ class Form < ActiveRecord::Base
     questionings.reject{|q| q.hidden?}
   end
 
-  # returns questionings that work with sms forms and are not hidden
+  # returns hash of questionings that work with sms forms and are not hidden
   def smsable_questionings
-    questionings.reject{|q| q.hidden? || !q.question.qtype.smsable?}
+    smsable_questionings = questionings.reject{|q| q.hidden? || !q.question.qtype.smsable?}
+    smsable_questionings.index_by.with_index { |_, i| i + 1 }
   end
 
   def questioning_with_code(c)

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -178,7 +178,7 @@ class Form < ActiveRecord::Base
   # returns hash of questionings that work with sms forms and are not hidden
   def smsable_questionings
     smsable_questionings = questionings.select(&:smsable?)
-    smsable_questionings.index_by.with_index { |_, i| i + 1 }
+    smsable_questionings.map.with_index { |q, i| [i + 1, q] }.to_h
   end
 
   def questioning_with_code(c)

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -177,7 +177,7 @@ class Form < ActiveRecord::Base
 
   # returns hash of questionings that work with sms forms and are not hidden
   def smsable_questionings
-    smsable_questionings = questionings.reject{|q| q.hidden? || !q.question.qtype.smsable?}
+    smsable_questionings = questionings.select(&:smsable?)
     smsable_questionings.index_by.with_index { |_, i| i + 1 }
   end
 

--- a/app/models/questioning.rb
+++ b/app/models/questioning.rb
@@ -86,6 +86,11 @@ class Questioning < FormItem
     form.questionings.reject{ |q| q == self || (q.full_rank <=> full_rank) == 1 }
   end
 
+  # Returns smsable forms
+  def smsable?
+    !hidden? && question.qtype.smsable?
+  end
+
   # REFACTOR: should use translation delegation, from abandoned std_objs branch
   def method_missing(*args)
     # pass appropriate methods on to question

--- a/app/models/sms/decoder.rb
+++ b/app/models/sms/decoder.rb
@@ -94,7 +94,7 @@ class Sms::Decoder
 
       # otherwise, we it's cool, store it in the instance, and also store an indexed list of questionings
       @form = v.form
-      @questionings = @form.questionings.index_by(&:rank)
+      @questionings = @form.smsable_questionings
     end
 
     def current_ability

--- a/app/views/forms/sms_guide.html.erb
+++ b/app/views/forms/sms_guide.html.erb
@@ -42,7 +42,7 @@
     <%# loop over each question %>
     <% @form.smsable_questionings.each do |index, qing| %>
       <tr>
-        <td class="rank"><%= qing.full_dotted_rank %>.</td>
+        <td class="rank"><%= index %>.</td>
         <td class="question">
           <%= qing.question.name %>
           <%= reqd_sym if qing.required? %>

--- a/app/views/forms/sms_guide.html.erb
+++ b/app/views/forms/sms_guide.html.erb
@@ -40,7 +40,7 @@
     </tr>
 
     <%# loop over each question %>
-    <% @form.smsable_questionings.each do |qing| %>
+    <% @form.smsable_questionings.each do |index, qing| %>
       <tr>
         <td class="rank"><%= qing.full_dotted_rank %>.</td>
         <td class="question">
@@ -48,7 +48,7 @@
           <%= reqd_sym if qing.required? %>
         </td>
         <td class="answers">
-          <%= answer_space(" #{qing.rank}.") %>
+          <%= answer_space(" #{index}.") %>
         </td>
       </tr>
 

--- a/spec/models/sms/sms_decoder_spec.rb
+++ b/spec/models/sms/sms_decoder_spec.rb
@@ -358,6 +358,11 @@ describe Sms::Decoder do
     end
   end
 
+  it "form with qing groups should work" do
+    create_form(questions: ['integer', %w(text date), 'date'])
+    assert_decoding(body: "#{@form.code} 1.3 2.coffee and bagels 3.20151225 4.20160101", answers: [3, "coffee and bagels", Date.new(2015, 12, 25), Date.new(2016, 01, 01)])
+  end
+
   private
 
   def create_form(options)
@@ -385,15 +390,15 @@ describe Sms::Decoder do
     expect(response.form_id).to eq(@form.id)
 
     # ensure the answers match the expected ones
-    @form.root_questionings.each do |qing|
+    @form.smsable_questionings.each do |index, qing|
       # ensure an expected answer was given for this question
       expect(options[:answers].size >= qing.rank).to be_truthy, "No expected answer was given for question #{qing.rank}"
 
       # copy the expected value
-      expected = options[:answers][qing.rank - 1]
+      expected = options[:answers][index - 1]
 
       # replace the array index with nil so that we know this one has been looked at
-      options[:answers][qing.rank - 1] = nil
+      options[:answers][index - 1] = nil
 
       ansset = response.answer_set_for_questioning(qing)
 


### PR DESCRIPTION
* Makes `smsable_questionings` return an indexed hash
* Changes questionings object in SMS decoder to `smsable_questionings` hash
* Prints smsable_questionings index in SMS guide