### PR TITLE
use dir=rtl on Arabic pages

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <% body = yield %>
 <% ctlr_action_name = "#{route_key}_#{controller.action_name.gsub('update', 'edit').gsub('create', 'new')}" %>
 <!DOCTYPE html>
-<html>
+<html dir="<%= t('locale_dir', default: 'ltr') %>">
 <head>
   <title><%= configatron.site_name %><%= (ttl = title(:text_only => true)).blank? ? "" : ": #{ttl}" %></title>
 

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -1,6 +1,7 @@
 ar:
   # This should be the name of the language as written in that language, e.g. English, Français, Español, etc.
   locale_name: "انكليزي"
+  locale_dir: "rtl"
 
   # common words (should be capitalized except for those that obviously shouldn't like and, or, e.g., etc.)
   common:


### PR DESCRIPTION
Last year before there was an Arabic locale, I added some CSS which supports right-to-left language layout: #131 

This would add a field to the locale file, allowing Arabic and other languages to set the dir attribute on the top-level HTML element.

Default value is dir=ltr