### PR TITLE
5961 dont notify admin for 404

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -20,8 +20,7 @@ class ApplicationController < ActionController::Base
   rescue_from CanCan::AccessDenied, with: :handle_access_denied
   rescue_from RecentLoginRequiredError, with: :handle_recent_login_required
   rescue_from ActionController::ParameterMissing, with: :handle_parameter_missing
-  rescue_from ActionController::RecordNotFound, with: :handle_not_found
-  rescue_from ActionController::RoutingError, with: :handle_not_found
+  rescue_from ActiveRecord::RecordNotFound, with: :handle_not_found
   rescue_from ActionController::InvalidAuthenticityToken, with: :handle_access_denied
 
   before_filter(:check_route)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -21,7 +21,7 @@ class ApplicationController < ActionController::Base
   rescue_from RecentLoginRequiredError, with: :handle_recent_login_required
   rescue_from ActionController::ParameterMissing, with: :handle_parameter_missing
   rescue_from ActiveRecord::RecordNotFound, with: :handle_not_found
-  rescue_from ActionController::InvalidAuthenticityToken, with: :handle_access_denied
+  rescue_from ActionController::InvalidAuthenticityToken, with: :handle_invalid_authenticity_token
 
   before_filter(:check_route)
   before_filter(:remove_missionchange_flag)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -20,6 +20,9 @@ class ApplicationController < ActionController::Base
   rescue_from CanCan::AccessDenied, with: :handle_access_denied
   rescue_from RecentLoginRequiredError, with: :handle_recent_login_required
   rescue_from ActionController::ParameterMissing, with: :handle_parameter_missing
+  rescue_from ActionController::RecordNotFound, with: :handle_not_found
+  rescue_from ActionController::RoutingError, with: :handle_not_found
+  rescue_from ActionController::InvalidAuthenticityToken, with: :handle_access_denied
 
   before_filter(:check_route)
   before_filter(:remove_missionchange_flag)

--- a/app/controllers/concerns/application_controller/error_handling.rb
+++ b/app/controllers/concerns/application_controller/error_handling.rb
@@ -20,4 +20,5 @@ module Concerns::ApplicationController::ErrorHandling
 
   def handle_invalid_authenticity_token
     render nothing:true, status: 401
+  end
 end

--- a/app/controllers/concerns/application_controller/error_handling.rb
+++ b/app/controllers/concerns/application_controller/error_handling.rb
@@ -14,11 +14,11 @@ module Concerns::ApplicationController::ErrorHandling
     raise exception unless options[:dont_re_raise]
   end
 
-  def handle_not_found
-    render nothing: true, status: 404
+  def handle_not_found(exception, options = {})
+    raise exception unless options[:dont_re_raise]
   end
 
-  def handle_invalid_authenticity_token
-    render nothing:true, status: 401
+  def handle_invalid_authenticity_token(exception, options = {})
+    raise exception unless options[:dont_re_raise]
   end
 end

--- a/app/controllers/concerns/application_controller/error_handling.rb
+++ b/app/controllers/concerns/application_controller/error_handling.rb
@@ -17,4 +17,7 @@ module Concerns::ApplicationController::ErrorHandling
   def handle_not_found
     render nothing: true, status: 404
   end
+
+  def handle_invalid_authenticity_token
+    render nothing:true, status: 401
 end

--- a/app/controllers/concerns/application_controller/error_handling.rb
+++ b/app/controllers/concerns/application_controller/error_handling.rb
@@ -13,4 +13,8 @@ module Concerns::ApplicationController::ErrorHandling
     # still show error page unless requested not to
     raise exception unless options[:dont_re_raise]
   end
+
+  def handle_not_found
+    render nothing: true, status: 404
+  end
 end

--- a/spec/controllers/odk_submission_spec.rb
+++ b/spec/controllers/odk_submission_spec.rb
@@ -47,8 +47,7 @@ describe "odk submissions", type: :request do
     end
 
     it "should fail for non-existent mission" do
-      do_submission("/m/foo/submission")
-      expect(response.response_code).to eq 404
+      expect { do_submission("/m/foo/submission") }.to raise_error(ActiveRecord::RecordNotFound)
     end
 
     it "should return error 426 upgrade required if old version of form" do

--- a/spec/controllers/odk_submission_spec.rb
+++ b/spec/controllers/odk_submission_spec.rb
@@ -47,7 +47,8 @@ describe "odk submissions", type: :request do
     end
 
     it "should fail for non-existent mission" do
-      expect { do_submission("/m/foo/submission") }.to raise_error(ActiveRecord::RecordNotFound)
+      do_submission("/m/foo/submission")
+      expect(response.response_code).to eq 404
     end
 
     it "should return error 426 upgrade required if old version of form" do

--- a/spec/features/questions_flow_spec.rb
+++ b/spec/features/questions_flow_spec.rb
@@ -50,7 +50,7 @@ feature "questions flow" do
     click_button("Search")
   end
 
-  scenario 'question tag add/remove', js: true do
+  scenario 'question tag add/remove', :investigate, js: true do
     tag_add_remove_test(
       qtype: 'question',
       edit_path: edit_question_path(@question1, mode: 'm', mission_name: @mission.compact_name, locale: 'en'),


### PR DESCRIPTION
This will not send emails to admins for record not found. Tested manually that without changes, an email is sent on an ActiveRecord::RecordNotFound error and with changes, the email is not sent. Instead it just renders nothing with status 404. It also has a rescue block for InvalidAuthenticityToken but this is not tested. We'll see if the emails stop in production.