### PR TITLE
5917 print only for observers

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -391,7 +391,7 @@ class User < ApplicationRecord
     end
 
     def print_password_reset_only_for_observer
-      if reset_password_method && !observer_only?
+      if reset_password_method == "print" && !observer_only?
         errors.add(:reset_password_method, :print_password_reset_only_for_observer)
       end
     end

--- a/app/views/users/_reset_password_method.html.erb
+++ b/app/views/users/_reset_password_method.html.erb
@@ -6,5 +6,7 @@
 <% prefix = form.object.new_record? ? "" : t("user.reset_password_and") + " " %>
 <%= form.radio_button(:reset_password_method, "email") %>
 <%= form.label(:reset_password_method_email, (prefix + t("user.send_email_instructions")).capitalize) %><br/>
-<%= form.radio_button(:reset_password_method, "print") %>
-<%= form.label(:reset_password_method_print, (prefix + t("user.show_printable_instructions")).capitalize) %><br/>
+<%= unless admin_mode? %>
+  <%= form.radio_button(:reset_password_method, "print") %>
+  <%= form.label(:reset_password_method_print, (prefix + t("user.show_printable_instructions")).capitalize) %><br/>
+<% end %>

--- a/app/views/users/_reset_password_method.html.erb
+++ b/app/views/users/_reset_password_method.html.erb
@@ -6,7 +6,7 @@
 <% prefix = form.object.new_record? ? "" : t("user.reset_password_and") + " " %>
 <%= form.radio_button(:reset_password_method, "email") %>
 <%= form.label(:reset_password_method_email, (prefix + t("user.send_email_instructions")).capitalize) %><br/>
-<%= unless admin_mode? %>
+<% if @show_print_option %>
   <%= form.radio_button(:reset_password_method, "print") %>
   <%= form.label(:reset_password_method_print, (prefix + t("user.show_printable_instructions")).capitalize) %><br/>
 <% end %>

--- a/app/views/users/form.html.erb
+++ b/app/views/users/form.html.erb
@@ -48,7 +48,7 @@
 
       <% verb = @user.new_record? ? "choose" : "reset" %>
       <% label = t("user.reset_password_label_" + verb) %>
-      <% @show_print_option = !admin_mode? && (!@user.new_record? && @user.observer_only?) %>
+      <% @show_print_option = !admin_mode? && (@user.new_record? || @user.observer_only?) %>
       <% hint = t("user.reset_password_hint_" + verb) + " " + t("user.reset_password_hint_ending", verb: t("common." + verb).downcase) %>
       <%= f.field(:reset_password_method, label: label, hint: hint, show_print_option: @show_print_option, partial: "reset_password_method") %>
 

--- a/app/views/users/form.html.erb
+++ b/app/views/users/form.html.erb
@@ -48,8 +48,9 @@
 
       <% verb = @user.new_record? ? "choose" : "reset" %>
       <% label = t("user.reset_password_label_" + verb) %>
+      <% @show_print_option = !admin_mode? && (!@user.new_record? && @user.observer_only?) %>
       <% hint = t("user.reset_password_hint_" + verb) + " " + t("user.reset_password_hint_ending", verb: t("common." + verb).downcase) %>
-      <%= f.field(:reset_password_method, label: label, hint: hint, partial: "reset_password_method") %>
+      <%= f.field(:reset_password_method, label: label, hint: hint, show_print_option: @show_print_option, partial: "reset_password_method") %>
 
     <% end %>
   <% end %>

--- a/app/views/users/form.html.erb
+++ b/app/views/users/form.html.erb
@@ -50,7 +50,7 @@
       <% label = t("user.reset_password_label_" + verb) %>
       <% @show_print_option = !admin_mode? && (@user.new_record? || @user.observer_only?) %>
       <% hint = t("user.reset_password_hint_" + verb) + " " + t("user.reset_password_hint_ending", verb: t("common." + verb).downcase) %>
-      <%= f.field(:reset_password_method, label: label, hint: hint, show_print_option: @show_print_option, partial: "reset_password_method") %>
+      <%= f.field(:reset_password_method, label: label, hint: hint, partial: "reset_password_method") %>
 
     <% end %>
   <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2049,7 +2049,7 @@ en:
     profile_updated: "Profile updated successfully."
     reset_password_and: "Reset password and"
     reset_password_hint_choose: "Select how this user should get their password."
-    reset_password_hint_ending: "The system can send them an email with instructions on how to %{verb} the password online. When managing an observer within a mission, you can choose a printable instruction sheet including a randomly generated password."
+    reset_password_hint_ending: "The system can send them an email with instructions on how to %{verb} the password online. A printable instruction sheet including a randomly generated password is available within a mission for a user whose only role is observer."
     reset_password_hint_reset: "Choose whether and how to reset this user's password."
     reset_password_label_choose: "Password Creation"
     reset_password_label_reset: "Reset Password?"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -797,6 +797,7 @@ en:
               invalid: "Please use only unaccented letters, numbers, periods, and underscores."
             reset_password_method:
               cant_passwd_email: "You can't %{verb} password by email because you didn't specify an email address."
+              print_password_reset_only_for_observer: "Printed instructions are only available to observers. "
         user_batch:
           general: "User batch is invalid (see below)."
           internal: "An internal error occurred while proccessing your upload."
@@ -2047,8 +2048,8 @@ en:
     logout_success: "You have logged out successfully."
     profile_updated: "Profile updated successfully."
     reset_password_and: "Reset password and"
-    reset_password_hint_choose: "Choose how this user should get their password."
-    reset_password_hint_ending: "The system can either send them an email with instructions on how to %{verb} the password online, or display a printable instruction sheet including a randomly generated password."
+    reset_password_hint_choose: "Select how this user should get their password."
+    reset_password_hint_ending: "The system can send them an email with instructions on how to %{verb} the password online. When managing an observer within a mission, you can choose a printable instruction sheet including a randomly generated password."
     reset_password_hint_reset: "Choose whether and how to reset this user's password."
     reset_password_label_choose: "Password Creation"
     reset_password_label_reset: "Reset Password?"

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -21,7 +21,7 @@ FactoryGirl.define do
     login { Random.letters(8) }
     sequence(:name) { |n| "A User #{n}" }
     email { Random.letters(8) + '@example.com' }
-    reset_password_method "print"
+    reset_password_method "email"
     password { test_password }
     password_confirmation { test_password }
     phone { Random.phone_num }

--- a/spec/requests/user_management_spec.rb
+++ b/spec/requests/user_management_spec.rb
@@ -53,10 +53,6 @@ describe "user management" do
     end
   end
 
-
-
-
-
   private
 
   def test_create_user(mission)
@@ -64,7 +60,7 @@ describe "user management" do
     post("/en/m/#{mission.compact_name}/users", user: {
       name: "Alan Bob",
       login: "abob",
-      assignments_attributes: {"1" => {"mission_id" => mission.id, "role" => "staffer"}},
+      assignments_attributes: {"1" => {"mission_id" => mission.id, "role" => "observer"}},
       reset_password_method: "print"
     })
 


### PR DESCRIPTION
Print option is only visible when not in admin mode and (you are making a new user or editing a user who is only an observer). When creating a new user outside of admin mode, validation will flash error if try to print instructions for non observer. 

There is still a rare use case that an admin assigns a user as observer in mission A and staffer in mission B, and a coordinator for mission A goes to try to print out a reset password for observer, and the coordinator won't see the option to print & won't know why. The hint is still pretty long & unwieldy. Should I add a different hint if a user isn't 'observer_only?'