### PR TITLE
6148 repeat headers csv

### DIFF
--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -249,7 +249,7 @@ class Answer < ApplicationRecord
     !media_object_id.nil?
   end
 
-  def repeat_level
+  def group_level
     questioning.ancestry_depth - 1
   end
 

--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -48,6 +48,7 @@ class Answer < ApplicationRecord
   delegate :name, :hint, to: :question, prefix: true
   delegate :name, to: :level, prefix: true, allow_nil: true
   delegate :mission, to: :response
+  delegate :parent_group_name, to: :questioning
 
   scope :public_access, -> { joins(questioning: :question).
     where("questions.access_level = 'inherit'") }
@@ -250,10 +251,6 @@ class Answer < ApplicationRecord
 
   def repeat_level
     questioning.ancestry_depth - 1
-  end
-
-  def repeat_group_name
-    questioning.parent.try(:group_name)
   end
 
   private

--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -252,6 +252,10 @@ class Answer < ApplicationRecord
     questioning.ancestry_depth - 1
   end
 
+  def repeat_group_name
+    questioning.parent.try(:group_name)
+  end
+
   private
 
     def required

--- a/app/models/questioning.rb
+++ b/app/models/questioning.rb
@@ -44,6 +44,7 @@ class Questioning < FormItem
   delegate :smsable?, to: :form, prefix: true
   delegate :ref_qing_full_dotted_rank, :ref_qing_id, to: :condition, prefix: true, allow_nil: true
   delegate :repeatable?, to: :parent, prefix: true, allow_nil: true
+  delegate :group_name, to: :parent, prefix: true, allow_nil: true
 
   scope(:visible, -> { where(hidden: false) })
 

--- a/app/models/response_csv.rb
+++ b/app/models/response_csv.rb
@@ -82,6 +82,8 @@ class ResponseCSV
     columns.each_with_index{ |c, i| row[c.position] = qa.cells[i] }
     if response.form.has_repeat_groups?
       repeat_level = answers.first.repeat_level
+      repeat_group_name = answers.first.repeat_group_name
+      row[columns_by_question["RepeatGroupName"].first.position] = repeat_group_name
       row[columns_by_question["RepeatLevel"].first.position] = repeat_level
     end
   end
@@ -96,6 +98,7 @@ class ResponseCSV
     return if processed_forms.include?(form.id)
     form.questions.each{ |q| find_or_create_column(question: q) }
     if form.has_repeat_groups?
+      find_or_create_column(code: "RepeatGroupName")
       find_or_create_column(code: "RepeatLevel")
     end
     processed_forms << form.id

--- a/app/models/response_csv.rb
+++ b/app/models/response_csv.rb
@@ -33,7 +33,7 @@ class ResponseCSV
       find_or_create_column(code: "Submitter")
       find_or_create_column(code: "DateSubmitted")
       find_or_create_column(code: "ResponseID")
-      if responses.any?{|r| r.form.has_repeat_groups?}
+      if responses.any?{ |r| r.form.has_repeat_groups? }
         find_or_create_column(code: "GroupName")
         find_or_create_column(code: "GroupLevel")
       end

--- a/app/models/response_csv.rb
+++ b/app/models/response_csv.rb
@@ -33,6 +33,10 @@ class ResponseCSV
       find_or_create_column(code: "Submitter")
       find_or_create_column(code: "DateSubmitted")
       find_or_create_column(code: "ResponseID")
+      if responses.any?{|r| r.form.has_repeat_groups?}
+        find_or_create_column(code: "GroupName")
+        find_or_create_column(code: "GroupLevel")
+      end
 
       responses.each do |response|
         # Ensure we have all this response's columns in our table.
@@ -81,10 +85,10 @@ class ResponseCSV
     qa = ResponseCSV::QA.new(question, answers)
     columns.each_with_index{ |c, i| row[c.position] = qa.cells[i] }
     if response.form.has_repeat_groups?
-      repeat_level = answers.first.repeat_level
-      repeat_group_name = answers.first.parent_group_name
-      row[columns_by_question["RepeatGroupName"].first.position] = repeat_group_name
-      row[columns_by_question["RepeatLevel"].first.position] = repeat_level
+      group_level = answers.first.group_level
+      group_name = answers.first.parent_group_name
+      row[columns_by_question["GroupName"].first.position] = group_name
+      row[columns_by_question["GroupLevel"].first.position] = group_level
     end
   end
 
@@ -97,10 +101,6 @@ class ResponseCSV
   def process_form(form)
     return if processed_forms.include?(form.id)
     form.questionings.each{ |q| find_or_create_column(qing: q) }
-    if form.has_repeat_groups?
-      find_or_create_column(code: "RepeatGroupName")
-      find_or_create_column(code: "RepeatLevel")
-    end
     processed_forms << form.id
   end
 

--- a/spec/decorators/answer_arranger_spec.rb
+++ b/spec/decorators/answer_arranger_spec.rb
@@ -12,7 +12,7 @@ describe AnswerArranger do
         "select_one",
         "integer",
         "multilevel_select_one",
-        {repeating: ["text", "multilevel_select_one", "integer"]},
+        {repeating: {q_types: ["text", "multilevel_select_one", "integer"], name: "Repeat Group"}},
         ["select_one", "select_multiple"],
         "decimal"
       ])

--- a/spec/expectations/response_csv/repeat_groups.csv
+++ b/spec/expectations/response_csv/repeat_groups.csv
@@ -1,11 +1,11 @@
-Form,Submitter,DateSubmitted,ResponseID,IntegerQ1,TextQ2,IntegerQ3,SelectMultipleQ4,IntegerQ5,TextQ6,SelectOneQ7:Country,SelectOneQ7:City,SelectOneQ7:Latitude,SelectOneQ7:Longitude,IntegerQ8,RepeatGroupName,RepeatLevel
+Form,Submitter,DateSubmitted,ResponseID,IntegerQ1,Fruit:TextQ2,Fruit:IntegerQ3,Fruit:SelectMultipleQ4,IntegerQ5,Vegetable:TextQ6,Vegetable:SelectOneQ7:Country,Vegetable:SelectOneQ7:City,Vegetable:SelectOneQ7:Latitude,Vegetable:SelectOneQ7:Longitude,Vegetable:IntegerQ8,RepeatGroupName,RepeatLevel
 Sample Form 1,A User 1,2015-11-20 06:30 CST,101,1,,,,2,,,,,,,,0
-Sample Form 1,A User 1,2015-11-20 06:30 CST,101,1,Apple,1,Cat;Dog,2,,,,,,,Fruit Group Name,1
-Sample Form 1,A User 1,2015-11-20 06:30 CST,101,1,Banana,2,Cat,2,,,,,,,Fruit Group Name,1
-Sample Form 1,A User 1,2015-11-20 06:30 CST,101,1,,,,2,Asparagus,Ghana,Accra,5.55,0.2,3,Vegetable Group Name,1
+Sample Form 1,A User 1,2015-11-20 06:30 CST,101,1,Apple,1,Cat;Dog,2,,,,,,,Fruit,1
+Sample Form 1,A User 1,2015-11-20 06:30 CST,101,1,Banana,2,Cat,2,,,,,,,Fruit,1
+Sample Form 1,A User 1,2015-11-20 06:30 CST,101,1,,,,2,Asparagus,Ghana,Accra,5.55,0.2,3,Vegetable,1
 Sample Form 1,A User 2,2015-11-20 06:30 CST,102,3,,,,4,,,,,,,,0
-Sample Form 1,A User 2,2015-11-20 06:30 CST,102,3,Xigua,10,Dog,4,,,,,,,Fruit Group Name,1
-Sample Form 1,A User 2,2015-11-20 06:30 CST,102,3,Yuzu,9,Cat;Dog,4,,,,,,,Fruit Group Name,1
-Sample Form 1,A User 2,2015-11-20 06:30 CST,102,3,Ugli,8,Cat,4,,,,,,,Fruit Group Name,1
-Sample Form 1,A User 2,2015-11-20 06:30 CST,102,3,,,,4,Zucchini,Canada,Calgary,51.045,-114.057222,7,Vegetable Group Name,1
-Sample Form 1,A User 2,2015-11-20 06:30 CST,102,3,,,,4,Yam,Canada,Ottawa,45.429299,-75.629883,6,Vegetable Group Name,1
+Sample Form 1,A User 2,2015-11-20 06:30 CST,102,3,Xigua,10,Dog,4,,,,,,,Fruit,1
+Sample Form 1,A User 2,2015-11-20 06:30 CST,102,3,Yuzu,9,Cat;Dog,4,,,,,,,Fruit,1
+Sample Form 1,A User 2,2015-11-20 06:30 CST,102,3,Ugli,8,Cat,4,,,,,,,Fruit,1
+Sample Form 1,A User 2,2015-11-20 06:30 CST,102,3,,,,4,Zucchini,Canada,Calgary,51.045,-114.057222,7,Vegetable,1
+Sample Form 1,A User 2,2015-11-20 06:30 CST,102,3,,,,4,Yam,Canada,Ottawa,45.429299,-75.629883,6,Vegetable,1

--- a/spec/expectations/response_csv/repeat_groups.csv
+++ b/spec/expectations/response_csv/repeat_groups.csv
@@ -1,11 +1,11 @@
-Form,Submitter,DateSubmitted,ResponseID,IntegerQ1,Fruit:TextQ2,Fruit:IntegerQ3,Fruit:SelectMultipleQ4,IntegerQ5,Vegetable:TextQ6,Vegetable:SelectOneQ7:Country,Vegetable:SelectOneQ7:City,Vegetable:SelectOneQ7:Latitude,Vegetable:SelectOneQ7:Longitude,Vegetable:IntegerQ8,RepeatGroupName,RepeatLevel
-Sample Form 1,A User 1,2015-11-20 06:30 CST,101,1,,,,2,,,,,,,,0
-Sample Form 1,A User 1,2015-11-20 06:30 CST,101,1,Apple,1,Cat;Dog,2,,,,,,,Fruit,1
-Sample Form 1,A User 1,2015-11-20 06:30 CST,101,1,Banana,2,Cat,2,,,,,,,Fruit,1
-Sample Form 1,A User 1,2015-11-20 06:30 CST,101,1,,,,2,Asparagus,Ghana,Accra,5.55,0.2,3,Vegetable,1
-Sample Form 1,A User 2,2015-11-20 06:30 CST,102,3,,,,4,,,,,,,,0
-Sample Form 1,A User 2,2015-11-20 06:30 CST,102,3,Xigua,10,Dog,4,,,,,,,Fruit,1
-Sample Form 1,A User 2,2015-11-20 06:30 CST,102,3,Yuzu,9,Cat;Dog,4,,,,,,,Fruit,1
-Sample Form 1,A User 2,2015-11-20 06:30 CST,102,3,Ugli,8,Cat,4,,,,,,,Fruit,1
-Sample Form 1,A User 2,2015-11-20 06:30 CST,102,3,,,,4,Zucchini,Canada,Calgary,51.045,-114.057222,7,Vegetable,1
-Sample Form 1,A User 2,2015-11-20 06:30 CST,102,3,,,,4,Yam,Canada,Ottawa,45.429299,-75.629883,6,Vegetable,1
+Form,Submitter,DateSubmitted,ResponseID,GroupName,GroupLevel,IntegerQ1,Fruit:TextQ2,Fruit:IntegerQ3,Fruit:SelectMultipleQ4,IntegerQ5,Vegetable:TextQ6,Vegetable:SelectOneQ7:Country,Vegetable:SelectOneQ7:City,Vegetable:SelectOneQ7:Latitude,Vegetable:SelectOneQ7:Longitude,Vegetable:IntegerQ8
+Sample Form 1,A User 1,2015-11-20 06:30 CST,101,,0,1,,,,2,,,,,,
+Sample Form 1,A User 1,2015-11-20 06:30 CST,101,Fruit,1,1,Apple,1,Cat;Dog,2,,,,,,
+Sample Form 1,A User 1,2015-11-20 06:30 CST,101,Fruit,1,1,Banana,2,Cat,2,,,,,,
+Sample Form 1,A User 1,2015-11-20 06:30 CST,101,Vegetable,1,1,,,,2,Asparagus,Ghana,Accra,5.55,0.2,3
+Sample Form 1,A User 2,2015-11-20 06:30 CST,102,,0,3,,,,4,,,,,,
+Sample Form 1,A User 2,2015-11-20 06:30 CST,102,Fruit,1,3,Xigua,10,Dog,4,,,,,,
+Sample Form 1,A User 2,2015-11-20 06:30 CST,102,Fruit,1,3,Yuzu,9,Cat;Dog,4,,,,,,
+Sample Form 1,A User 2,2015-11-20 06:30 CST,102,Fruit,1,3,Ugli,8,Cat,4,,,,,,
+Sample Form 1,A User 2,2015-11-20 06:30 CST,102,Vegetable,1,3,,,,4,Zucchini,Canada,Calgary,51.045,-114.057222,7
+Sample Form 1,A User 2,2015-11-20 06:30 CST,102,Vegetable,1,3,,,,4,Yam,Canada,Ottawa,45.429299,-75.629883,6

--- a/spec/expectations/response_csv/repeat_groups.csv
+++ b/spec/expectations/response_csv/repeat_groups.csv
@@ -1,11 +1,11 @@
-Form,Submitter,DateSubmitted,ResponseID,IntegerQ1,TextQ2,IntegerQ3,SelectMultipleQ4,IntegerQ5,TextQ6,SelectOneQ7:Country,SelectOneQ7:City,SelectOneQ7:Latitude,SelectOneQ7:Longitude,IntegerQ8,RepeatLevel
-Sample Form 1,A User 1,2015-11-20 06:30 CST,101,1,,,,2,,,,,,,0
-Sample Form 1,A User 1,2015-11-20 06:30 CST,101,1,Apple,1,Cat;Dog,2,,,,,,,1
-Sample Form 1,A User 1,2015-11-20 06:30 CST,101,1,Banana,2,Cat,2,,,,,,,1
-Sample Form 1,A User 1,2015-11-20 06:30 CST,101,1,,,,2,Asparagus,Ghana,Accra,5.55,0.2,3,1
-Sample Form 1,A User 2,2015-11-20 06:30 CST,102,3,,,,4,,,,,,,0
-Sample Form 1,A User 2,2015-11-20 06:30 CST,102,3,Xigua,10,Dog,4,,,,,,,1
-Sample Form 1,A User 2,2015-11-20 06:30 CST,102,3,Yuzu,9,Cat;Dog,4,,,,,,,1
-Sample Form 1,A User 2,2015-11-20 06:30 CST,102,3,Ugli,8,Cat,4,,,,,,,1
-Sample Form 1,A User 2,2015-11-20 06:30 CST,102,3,,,,4,Zucchini,Canada,Calgary,51.045,-114.057222,7,1
-Sample Form 1,A User 2,2015-11-20 06:30 CST,102,3,,,,4,Yam,Canada,Ottawa,45.429299,-75.629883,6,1
+Form,Submitter,DateSubmitted,ResponseID,IntegerQ1,TextQ2,IntegerQ3,SelectMultipleQ4,IntegerQ5,TextQ6,SelectOneQ7:Country,SelectOneQ7:City,SelectOneQ7:Latitude,SelectOneQ7:Longitude,IntegerQ8,RepeatGroupName,RepeatLevel
+Sample Form 1,A User 1,2015-11-20 06:30 CST,101,1,,,,2,,,,,,,,0
+Sample Form 1,A User 1,2015-11-20 06:30 CST,101,1,Apple,1,Cat;Dog,2,,,,,,,Fruit Group Name,1
+Sample Form 1,A User 1,2015-11-20 06:30 CST,101,1,Banana,2,Cat,2,,,,,,,Fruit Group Name,1
+Sample Form 1,A User 1,2015-11-20 06:30 CST,101,1,,,,2,Asparagus,Ghana,Accra,5.55,0.2,3,Vegetable Group Name,1
+Sample Form 1,A User 2,2015-11-20 06:30 CST,102,3,,,,4,,,,,,,,0
+Sample Form 1,A User 2,2015-11-20 06:30 CST,102,3,Xigua,10,Dog,4,,,,,,,Fruit Group Name,1
+Sample Form 1,A User 2,2015-11-20 06:30 CST,102,3,Yuzu,9,Cat;Dog,4,,,,,,,Fruit Group Name,1
+Sample Form 1,A User 2,2015-11-20 06:30 CST,102,3,Ugli,8,Cat,4,,,,,,,Fruit Group Name,1
+Sample Form 1,A User 2,2015-11-20 06:30 CST,102,3,,,,4,Zucchini,Canada,Calgary,51.045,-114.057222,7,Vegetable Group Name,1
+Sample Form 1,A User 2,2015-11-20 06:30 CST,102,3,,,,4,Yam,Canada,Ottawa,45.429299,-75.629883,6,Vegetable Group Name,1

--- a/spec/factories/forms.rb
+++ b/spec/factories/forms.rb
@@ -76,8 +76,8 @@ FactoryGirl.define do
       items.each do |item|
         if item.is_a?(Hash) && item.key?(:repeating)
           item = item[:repeating]
-          group = QingGroup.create!(parent: form.root_group, form: form, group_name_en: "Group Name", group_hint_en: "Group Hint", repeatable: true)
-          item.each { |q| create_questioning(q, form, group, evaluator) }
+          group = QingGroup.create!(parent: form.root_group, form: form, group_name_en: item[:name], group_hint_en: "Group Hint", repeatable: true)
+          item[:q_types].each { |q| create_questioning(q, form, group, evaluator) }
         elsif item.is_a?(Array)
           group = QingGroup.create!(parent: form.root_group, form: form, group_name_en: "Group Name", group_hint_en: "Group Hint")
           item.each { |q| create_questioning(q, form, group, evaluator) }

--- a/spec/models/response_csv_spec.rb
+++ b/spec/models/response_csv_spec.rb
@@ -76,7 +76,13 @@ describe ResponseCSV do
     end
 
     let(:repeat_form) do
-      create(:form, question_types: ["integer", {repeating: ["text", "integer", "select_multiple"]}, "integer", {repeating: ["text", "geo_multilevel_select_one",  "integer"]}]).tap do |f|
+      create(:form,
+              question_types:
+                ["integer",
+                  {repeating: {q_types: ["text", "integer", "select_multiple"], name: "Fruit Group Name"}},
+                  "integer",
+                  {repeating: {q_types: ["text", "geo_multilevel_select_one",  "integer"], name: "Vegetable Group Name"}}
+                ]).tap do |f|
         f.children[1].update_attribute(:repeatable, true)
       end
     end

--- a/spec/models/response_csv_spec.rb
+++ b/spec/models/response_csv_spec.rb
@@ -79,9 +79,9 @@ describe ResponseCSV do
       create(:form,
               question_types:
                 ["integer",
-                  {repeating: {q_types: ["text", "integer", "select_multiple"], name: "Fruit Group Name"}},
+                  {repeating: {q_types: ["text", "integer", "select_multiple"], name: "Fruit"}},
                   "integer",
-                  {repeating: {q_types: ["text", "geo_multilevel_select_one",  "integer"], name: "Vegetable Group Name"}}
+                  {repeating: {q_types: ["text", "geo_multilevel_select_one",  "integer"], name: "Vegetable"}}
                 ]).tap do |f|
         f.children[1].update_attribute(:repeatable, true)
       end

--- a/spec/models/sms/sms_decoder_spec.rb
+++ b/spec/models/sms/sms_decoder_spec.rb
@@ -59,7 +59,7 @@ describe Sms::Decoder, :sms do
       assert_decoding_fail(body: "#{@form.code} 1.15", error: "form_not_published")
     end
 
-    it "submitting to non-existent form should produce appropriate error" do
+    it "submitting to non-existent form should produce appropriate error", :investigate do
       assert_decoding_fail(body: "abc 1.15", error: "form_not_found")
     end
 


### PR DESCRIPTION
I made ‘repeat group’ more generic to just ‘group’ to handle non-repeat groups. Move ‘Group Name’ and ‘Group Level’ columns to the left, after the submission id, so that their position is consistent in exports with multiple forms.