### PR TITLE
6843: Refactored AnswerArranger 

### DIFF
--- a/app/controllers/responses_controller.rb
+++ b/app/controllers/responses_controller.rb
@@ -246,8 +246,7 @@ class ResponsesController < ApplicationController
     # Prepare the AnswerNodes.
     set_read_only
     @nodes = AnswerArranger.new(@response,
-      # No point in showing missing answers in show mode.
-      include_missing_answers: params[:action] != "show",
+      placeholders: params[:action] == "show" ? :except_repeats : :all,
       # Must preserve submitted answers when in create/update action.
       dont_load_answers: %w(create update).include?(params[:action])
     ).build.nodes

--- a/app/models/response.rb
+++ b/app/models/response.rb
@@ -337,7 +337,7 @@ class Response < ApplicationRecord
   private
 
   def normalize_answers
-    AnswerArranger.new(self, include_missing_answers: false, dont_load_answers: true).build.normalize
+    AnswerArranger.new(self, placeholders: :none, dont_load_answers: true).build.normalize
   end
 
   def form_in_mission

--- a/spec/factories/responses.rb
+++ b/spec/factories/responses.rb
@@ -5,6 +5,7 @@ module ResponseFactoryHelper
       if i < values.size
         value = values[i]
         if item.is_a?(QingGroup)
+          next if value.nil?
           unless value.is_a?(Array)
             raise "expecting array of answer values for #{item.group_name}, got #{value.inspect}"
           end

--- a/spec/models/answer_instance_spec.rb
+++ b/spec/models/answer_instance_spec.rb
@@ -14,7 +14,7 @@ describe AnswerInstance do
       ])
     end
     let(:root_instance) do
-      AnswerArranger.new(response, include_missing_answers: false, dont_load_answers: true).build
+      AnswerArranger.new(response, placeholders: :none, dont_load_answers: true).build
     end
 
     context "with blank instance" do


### PR DESCRIPTION
This PR refactors AnswerArranger to allow finer grained control over what placeholders get inserted when answer structure is being built. It's so we can show a blank non-repeat group in show mode, but not a blank repeat group, per Dottie's request.