### PR TITLE
7180 computed conditions

### DIFF
--- a/app/decorators/odk/qing_group_decorator.rb
+++ b/app/decorators/odk/qing_group_decorator.rb
@@ -11,6 +11,18 @@ module Odk
       decorate_collection(object.sorted_children)
     end
 
+    def bind_tag(xpath_prefix: "/data")
+      tag(:bind, nodeset: xpath(xpath_prefix), relevant: relevance)
+    end
+
+    def note_bind_tag(xpath_prefix: "/data")
+      tag(:bind, nodeset: xpath(xpath_prefix) << "/#{odk_code}-header", readonly: "true()", type: "string")
+    end
+
+    def xpath(prefix = "/data")
+      "#{prefix}/#{odk_code}"
+    end
+
     # Duck type
     def code
       nil

--- a/app/helpers/odk_helper.rb
+++ b/app/helpers/odk_helper.rb
@@ -85,15 +85,6 @@ module OdkHelper
     end
   end
 
-  # note: _readonly is used to get around the 'readonly' html attribute
-  def note_binding(group, xpath_prefix)
-    tag(:bind, {
-      "nodeset" => "#{xpath_prefix}/#{group.odk_code}-header",
-      "_readonly" => "true()",
-      "type" => "string"
-    }.reject { |k,v| v.nil? }).gsub(/_readonly=/, "readonly=").html_safe
-  end
-
   # For the given subqing, returns an xpath expression for the itemset tag nodeset attribute.
   # E.g. instance('os16')/root/item or
   #      instance('os16')/root/item[parent_id=/data/q2_1] or

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -95,8 +95,8 @@ class Form < ApplicationRecord
     root_group ? root_group.sorted_children.reject{ |q| q.is_a?(QingGroup) } : []
   end
 
-  def preordered_items
-    root_group.preordered_descendants
+  def preordered_items(eager_load:)
+    root_group.preordered_descendants(eager_load: eager_load)
   end
 
   def odk_download_cache_key

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -95,7 +95,7 @@ class Form < ApplicationRecord
     root_group ? root_group.sorted_children.reject{ |q| q.is_a?(QingGroup) } : []
   end
 
-  def preordered_items(eager_load:)
+  def preordered_items(eager_load: nil)
     root_group.preordered_descendants(eager_load: eager_load)
   end
 

--- a/app/models/form_item.rb
+++ b/app/models/form_item.rb
@@ -101,9 +101,9 @@ class FormItem < ApplicationRecord
   end
 
   def preordered_descendants(eager_load: nil)
-    rel = descendants.order(:rank)
-    rel = rel.includes(eager_load) if eager_load
-    self.class.sort_by_ancestry(rel) { |a, b| a.rank <=> b.rank }
+    items = descendants.order(:rank)
+    items = items.includes(eager_load) if eager_load
+    self.class.sort_by_ancestry(items) { |a, b| a.rank <=> b.rank }
   end
 
   def sorted_children

--- a/app/models/form_item.rb
+++ b/app/models/form_item.rb
@@ -100,7 +100,7 @@ class FormItem < ApplicationRecord
     end
   end
 
-  def preordered_descendants(eager_load:)
+  def preordered_descendants(eager_load: nil)
     rel = descendants.order(:rank)
     rel = rel.includes(eager_load) if eager_load
     self.class.sort_by_ancestry(rel) { |a, b| a.rank <=> b.rank }

--- a/app/models/form_item.rb
+++ b/app/models/form_item.rb
@@ -100,8 +100,10 @@ class FormItem < ApplicationRecord
     end
   end
 
-  def preordered_descendants
-    self.class.sort_by_ancestry(descendants.order(:rank)) { |a, b| a.rank <=> b.rank }
+  def preordered_descendants(eager_load:)
+    rel = descendants.order(:rank)
+    rel = rel.includes(eager_load) if eager_load
+    self.class.sort_by_ancestry(rel) { |a, b| a.rank <=> b.rank }
   end
 
   def sorted_children
@@ -154,6 +156,10 @@ class FormItem < ApplicationRecord
 
   def display_conditionally?
     display_if != "always" && display_conditions.any?
+  end
+
+  def condition_group
+    @condition_group ||= ConditionGroup.new(true_if: display_if, members: display_conditions)
   end
 
   def group?

--- a/app/models/forms/condition_computer.rb
+++ b/app/models/forms/condition_computer.rb
@@ -9,8 +9,11 @@ module Forms
     end
 
     def condition_group_for(item)
+      build_table if table.nil?
       table[item] || empty_group
     end
+
+    private
 
     def build_table
       self.table = {}
@@ -23,8 +26,6 @@ module Forms
         activate_rules_from_item(item)
       end
     end
-
-    private
 
     def add_display_conditions(item)
       add_to_table(item, item.condition_group) if item.display_conditionally?

--- a/app/models/forms/condition_computer.rb
+++ b/app/models/forms/condition_computer.rb
@@ -1,0 +1,69 @@
+# Computes display conditions that are implied from SkipRules.
+module Forms
+  class ConditionComputer
+    attr_accessor :form, :form_items, :table, :active_rules, :last_item_cache
+
+    def initialize(form)
+      self.form = form
+      self.form_items = form.preordered_items(eager_load: [:display_conditions, skip_rules: :conditions])
+    end
+
+    def condition_group_for(item)
+      table[item] || empty_group
+    end
+
+    def build_table
+      self.table = {}
+      self.active_rules = []
+      self.last_item_cache = {}
+      form_items.each do |item|
+        add_display_conditions(item)
+        deactivate_rules_if_at_dest_item(item)
+        process_active_rules_for_item(item)
+        activate_rules_from_item(item)
+      end
+    end
+
+    private
+
+    def add_display_conditions(item)
+      add_to_table(item, item.condition_group) if item.display_conditionally?
+    end
+
+    def deactivate_rules_if_at_dest_item(item)
+      active_rules.reject! { |r| r.dest_item == item }
+    end
+
+    # Scans through the active rules and adds them to the table for the given item when appropriate.
+    def process_active_rules_for_item(item)
+      active_rules.each do |rule|
+        next if item.descendants.include?(rule.dest_item)
+        next if item_has_been_added_to_ancestor?(rule.condition_group, item)
+        add_to_table(item, rule.condition_group)
+      end
+    end
+
+    # Adds skip rules from the current item to the active list.
+    def activate_rules_from_item(item)
+      active_rules.concat(item.skip_rules)
+    end
+
+    # Checks if a ConditionGroup has been added to the table for an ancestor of the given item.
+    def item_has_been_added_to_ancestor?(condition_group, item)
+      # Since we are doing a preorder traversal, we know that if the ConditionGroup has been added
+      # to an ancestor, it must have been the last item it was added to.
+      last_item = last_item_cache[condition_group]
+      last_item && item.ancestors.include?(last_item)
+    end
+
+    def add_to_table(item, condition_group)
+      table[item] ||= empty_group
+      table[item].members << condition_group
+      last_item_cache[condition_group] = item
+    end
+
+    def empty_group
+      ConditionGroup.new
+    end
+  end
+end

--- a/app/models/forms/condition_computer.rb
+++ b/app/models/forms/condition_computer.rb
@@ -1,11 +1,12 @@
 # Computes display conditions that are implied from SkipRules.
 module Forms
   class ConditionComputer
-    attr_accessor :form, :form_items, :table, :active_rules, :last_item_cache
+    attr_accessor :form, :preordered_form_items, :table, :active_rules, :last_item_cache
 
     def initialize(form)
       self.form = form
-      self.form_items = form.preordered_items(eager_load: [:display_conditions, skip_rules: :conditions])
+      self.preordered_form_items = form.preordered_items(
+        eager_load: [:display_conditions, skip_rules: :conditions])
     end
 
     def condition_group_for(item)
@@ -19,7 +20,7 @@ module Forms
       self.table = {}
       self.active_rules = []
       self.last_item_cache = {}
-      form_items.each do |item|
+      preordered_form_items.each do |item|
         add_display_conditions(item)
         deactivate_rules_if_at_dest_item(item)
         process_active_rules_for_item(item)

--- a/app/models/forms/condition_group.rb
+++ b/app/models/forms/condition_group.rb
@@ -1,3 +1,6 @@
+# Models a group of 1. conditions or 2. other groups of conditions
+# The nesting enables modeling something like this:
+# (Q2 > 5 || Q3 == 7) && !(Q2 > 9 || Q3 == 1) && !(Q2 > 0 && Q3 == 2) && !(Q2 < 12 || Q3 > 5)
 module Forms
   class ConditionGroup
     attr_accessor :members, :true_if, :negate

--- a/app/models/forms/condition_group.rb
+++ b/app/models/forms/condition_group.rb
@@ -1,0 +1,16 @@
+module Forms
+  class ConditionGroup
+    attr_accessor :members, :true_if, :negate
+    alias_method :negate?, :negate
+    
+    def initialize(members: [], true_if: "all_met", negate: false)
+      self.members = members
+      self.true_if = true_if
+      self.negate = negate
+    end
+
+    def empty?
+      members.empty?
+    end
+  end
+end

--- a/app/models/forms/condition_group.rb
+++ b/app/models/forms/condition_group.rb
@@ -2,15 +2,13 @@ module Forms
   class ConditionGroup
     attr_accessor :members, :true_if, :negate
     alias_method :negate?, :negate
-    
+
+    delegate :empty?, to: :members
+
     def initialize(members: [], true_if: "all_met", negate: false)
       self.members = members
       self.true_if = true_if
       self.negate = negate
-    end
-
-    def empty?
-      members.empty?
     end
   end
 end

--- a/app/models/skip_rule.rb
+++ b/app/models/skip_rule.rb
@@ -16,6 +16,10 @@ class SkipRule < ActiveRecord::Base
     destination.blank? && dest_item.blank? && conditions.all?(&:all_fields_blank?)
   end
 
+  def condition_group
+    @condition_group ||= ConditionGroup.new(true_if: skip_if, members: conditions, negate: true)
+  end
+
   private
 
   # Since conditionable is polymorphic, inverse is not available and we have to do this explicitly

--- a/app/views/forms/odk/_binding_node.xml.erb
+++ b/app/views/forms/odk/_binding_node.xml.erb
@@ -5,11 +5,10 @@
     <%= node.bind_tag(@form, subq, group: group_attr, xpath_prefix: xpath_prefix) %>
   <% end %>
 <% else %>
-  <% xpath = "#{xpath_prefix}/#{node.odk_code}" %>
-  <%= tag("bind", nodeset: xpath) %>
-  <%= note_binding(node, xpath) %>
+  <%= node.bind_tag(xpath_prefix: xpath_prefix) %>
+  <%= node.note_bind_tag(xpath_prefix: xpath_prefix) %>
   <% node.sorted_children.each do |child| %>
-    <%= render "forms/odk/binding_node", node: child, parent: node, xpath_prefix: xpath %>
+    <%= render "forms/odk/binding_node", node: child, parent: node, xpath_prefix: node.xpath(xpath_prefix) %>
   <% end %>
 <% end %>
 

--- a/spec/expectations/odk/forms/group_form.xml
+++ b/spec/expectations/odk/forms/group_form.xml
@@ -5,26 +5,27 @@
     <model>
       <instance>
         <data id="*form1*" version="*formver1*">
-          <*itemcode1*>
-            <*itemcode1*-header/>
-            <*itemcode2*/>
+          <*itemcode1*/>
+          <*itemcode2*>
+            <*itemcode2*-header/>
             <*itemcode3*/>
             <*itemcode4*/>
-          </*itemcode1*>
+            <*itemcode5*/>
+          </*itemcode2*>
         </data>
       </instance>
       <itext>
         <translation lang="English">
-          <text id="*itemcode1*-header:label">
+          <text id="*itemcode2*-header:label">
             <value>Group Name</value>
           </text>
-          <text id="*itemcode1*-header:hint">
+          <text id="*itemcode2*-header:hint">
             <value>Group Hint</value>
           </text>
-          <text id="*itemcode2*:label">
+          <text id="*itemcode1*:label">
             <value>Text Question Title 1</value>
           </text>
-          <text id="*itemcode2*:hint">
+          <text id="*itemcode1*:hint">
             <value>Question Hint 1</value>
           </text>
           <text id="*itemcode3*:label">
@@ -39,33 +40,44 @@
           <text id="*itemcode4*:hint">
             <value>Question Hint 3</value>
           </text>
+          <text id="*itemcode5*:label">
+            <value>Text Question Title 4</value>
+          </text>
+          <text id="*itemcode5*:hint">
+            <value>Question Hint 4</value>
+          </text>
         </translation>
       </itext>
-      <bind nodeset="/data/*itemcode1*"/>
-      <bind nodeset="/data/*itemcode1*/*itemcode1*-header" readonly="true()" type="string"/>
-      <bind nodeset="/data/*itemcode1*/*itemcode2*" type="string"/>
-      <bind nodeset="/data/*itemcode1*/*itemcode3*" type="string"/>
-      <bind nodeset="/data/*itemcode1*/*itemcode4*" type="string"/>
+      <bind nodeset="/data/*itemcode1*" type="string"/>
+      <bind nodeset="/data/*itemcode2*" relevant="/data/*itemcode1* = 'foo'"/>
+      <bind nodeset="/data/*itemcode2*/*itemcode2*-header" readonly="true()" type="string"/>
+      <bind nodeset="/data/*itemcode2*/*itemcode3*" type="string"/>
+      <bind nodeset="/data/*itemcode2*/*itemcode4*" type="string"/>
+      <bind nodeset="/data/*itemcode2*/*itemcode5*" type="string"/>
     </model>
   </h:head>
   <h:body>
+    <input ref="/data/*itemcode1*">
+      <label ref="jr:itext('*itemcode1*:label')"/>
+      <hint ref="jr:itext('*itemcode1*:hint')"/>
+    </input>
     <group>
       <label>Group Name</label>
       <group appearance="field-list">
-        <input ref="/data/*itemcode1*/*itemcode1*-header">
-          <hint ref="jr:itext('*itemcode1*-header:hint')"/>
+        <input ref="/data/*itemcode2*/*itemcode2*-header">
+          <hint ref="jr:itext('*itemcode2*-header:hint')"/>
         </input>
-        <input ref="/data/*itemcode1*/*itemcode2*">
-          <label ref="jr:itext('*itemcode2*:label')"/>
-          <hint ref="jr:itext('*itemcode2*:hint')"/>
-        </input>
-        <input ref="/data/*itemcode1*/*itemcode3*">
+        <input ref="/data/*itemcode2*/*itemcode3*">
           <label ref="jr:itext('*itemcode3*:label')"/>
           <hint ref="jr:itext('*itemcode3*:hint')"/>
         </input>
-        <input ref="/data/*itemcode1*/*itemcode4*">
+        <input ref="/data/*itemcode2*/*itemcode4*">
           <label ref="jr:itext('*itemcode4*:label')"/>
           <hint ref="jr:itext('*itemcode4*:hint')"/>
+        </input>
+        <input ref="/data/*itemcode2*/*itemcode5*">
+          <label ref="jr:itext('*itemcode5*:label')"/>
+          <hint ref="jr:itext('*itemcode5*:hint')"/>
         </input>
       </group>
     </group>

--- a/spec/models/forms/condition_computer_spec.rb
+++ b/spec/models/forms/condition_computer_spec.rb
@@ -1,0 +1,153 @@
+require "spec_helper"
+
+describe Forms::ConditionComputer do
+  context "with lots of conditions and skip rules" do
+    let(:form) do
+      create(:form, question_types: [
+        "integer",
+        "integer",
+        "integer",
+        ["integer", "integer", "integer"],
+        "integer",
+        ["integer", "integer", "integer"],
+        "integer"
+      ])
+    end
+    let(:computer) { Forms::ConditionComputer.new(form) }
+    let(:form_items) { computer.form_items }
+
+    # ConditionGroup doesn't really contain a _name attrib, but this can be useful
+    # for debugging.
+    let(:q3grp) { double(_name: :q3grp) }
+    let(:q5grp) { double(_name: :q5grp) }
+    let(:sr1grp) { double(_name: :sr1grp) }
+    let(:sr2grp) { double(_name: :sr2grp) }
+    let(:sr3grp) { double(_name: :sr3grp) }
+    let(:sr4grp) { double(_name: :sr4grp) }
+    let(:sr5grp) { double(_name: :sr5grp) }
+    let(:sr6grp) { double(_name: :sr6grp) }
+    let(:sr7grp) { double(_name: :sr7grp) }
+
+    let(:sr1) do # Root to root
+      build_skip_rule(form.c[0],
+        destination: "item",
+        dest_item: form.c[6]
+      )
+    end
+
+    let(:sr2) do # Root to group (not questioning)
+      build_skip_rule(form.c[0],
+        destination: "item",
+        dest_item: form.c[3] # This is a QingGroup
+      )
+    end
+
+    let(:sr3) do # Root to sub (this is a second SkipRule for form.c[1])
+      build_skip_rule(form.c[1],
+        destination: "item",
+        dest_item: form.c[3].c[1]
+      )
+    end
+
+    let(:sr4) do # Sub to same sub
+      build_skip_rule(form.c[3].c[0],
+        destination: "item",
+        dest_item: form.c[3].c[2]
+      )
+    end
+
+    let(:sr5) do # Sub to different sub
+      build_skip_rule(form.c[3].c[1],
+        destination: "item",
+        dest_item: form.c[5].c[2]
+      )
+    end
+
+    let(:sr6) do # Sub to root
+      build_skip_rule(form.c[3].c[2],
+        destination: "item",
+        dest_item: form.c[6]
+      )
+    end
+
+    let(:sr7) do # Sub to end
+      build_skip_rule(form.c[5].c[1],
+        destination: "end"
+      )
+    end
+
+    before do
+      # Set display conditions on questions 3 and 5 (should be included with computed)
+      allow(get_item(form.c[2])).to receive(:condition_group).and_return(q3grp)
+      allow(get_item(form.c[2])).to receive(:display_conditionally?).and_return(true)
+      allow(get_item(form.c[4])).to receive(:condition_group).and_return(q5grp)
+      allow(get_item(form.c[4])).to receive(:display_conditionally?).and_return(true)
+
+      allow(sr1).to receive(:condition_group).and_return(sr1grp)
+      allow(sr2).to receive(:condition_group).and_return(sr2grp)
+      allow(sr3).to receive(:condition_group).and_return(sr3grp)
+      allow(sr4).to receive(:condition_group).and_return(sr4grp)
+      allow(sr5).to receive(:condition_group).and_return(sr5grp)
+      allow(sr6).to receive(:condition_group).and_return(sr6grp)
+      allow(sr7).to receive(:condition_group).and_return(sr7grp)
+    end
+
+    # Table of expected conditions
+    # NUM
+    # Q1
+    # Q2          SR1 SR2
+    # Q3     DISP SR1 SR2 SR3
+    # G4          SR1
+    #  Q4.1               SR3
+    #  Q4.2                   SR4
+    #  Q4.3                       SR5
+    # Q5     DISP SR1             SR5 SR6
+    # G6          SR1                 SR6
+    #  Q6.1                       SR5
+    #  Q6.2                       SR5
+    #  Q6.3                               SR7
+    # Q7                                  SR7
+
+    it "returns correct ConditionGroups" do
+      computer.build_table
+      expect_condition_group(form.c[0], members: [])
+      expect_condition_group(form.c[1], members: [sr1grp, sr2grp])
+      expect_condition_group(form.c[2], members: [q3grp, sr1grp, sr2grp, sr3grp])
+      expect_condition_group(form.c[3], members: [sr1grp])
+      expect_condition_group(form.c[3].c[0], members: [sr3grp])
+      expect_condition_group(form.c[3].c[1], members: [sr4grp])
+      expect_condition_group(form.c[3].c[2], members: [sr5grp])
+      expect_condition_group(form.c[4], members: [q5grp, sr1grp, sr5grp, sr6grp])
+      expect_condition_group(form.c[5], members: [sr1grp, sr6grp])
+      expect_condition_group(form.c[5].c[0], members: [sr5grp])
+      expect_condition_group(form.c[5].c[1], members: [sr5grp])
+      expect_condition_group(form.c[5].c[2], members: [sr7grp])
+      expect_condition_group(form.c[6], members: [sr7grp])
+    end
+
+    # Checks that the ConditionGroup returned for the given FormItem looks right
+    # and has the expected member ConditionGroups.
+    def expect_condition_group(form_item, members:)
+      group = computer.condition_group_for(form_item)
+      if members.empty?
+        expect(group).to be_empty
+      else
+        expect(group.true_if).to eq "all_met"
+        expect(group.negate?).to be false
+        expect(group.members).to match_array(members)
+      end
+    end
+
+    def build_skip_rule(item, attribs)
+      get_item(item).skip_rules.build(attribs)
+    end
+
+    # We get form item references this way because if we stub `item` directly
+    # it will not be picked up by the Computer, because Computer iterates over a flat array
+    # of items returned by form.preordered_items. These objects are distinct from those returned
+    # by e.g. form.c[1]. Unfortunate! closure_tree has a way around this.
+    def get_item(item)
+      form_items.detect { |i| i.id == item.id }
+    end
+  end
+end

--- a/spec/models/forms/condition_computer_spec.rb
+++ b/spec/models/forms/condition_computer_spec.rb
@@ -7,7 +7,6 @@ describe Forms::ConditionComputer do
     let(:form) { create(:form, question_types: ["integer", "integer", ["integer", "integer"]]) }
 
     it "returns empty group for each question" do
-      computer.build_table
       expect_condition_group(form.c[0], empty: true)
       expect_condition_group(form.c[1], empty: true)
       expect_condition_group(form.c[2], empty: true)
@@ -125,7 +124,6 @@ describe Forms::ConditionComputer do
     # Q7                                  SR7
 
     it "returns correct ConditionGroups" do
-      computer.build_table
       expect_condition_group(form.c[0], empty: true)
       expect_condition_group(form.c[1], members: [sr1grp, sr2grp])
       expect_condition_group(form.c[2], members: [q3grp, sr1grp, sr2grp, sr3grp])

--- a/spec/models/forms/condition_computer_spec.rb
+++ b/spec/models/forms/condition_computer_spec.rb
@@ -27,7 +27,7 @@ describe Forms::ConditionComputer do
         "integer"
       ])
     end
-    let(:form_items) { computer.form_items }
+    let(:form_items) { computer.preordered_form_items }
 
     # ConditionGroup doesn't really contain a _name attrib, but this can be useful
     # for debugging.
@@ -44,49 +44,42 @@ describe Forms::ConditionComputer do
     let(:sr1) do # Root to root
       build_skip_rule(form.c[0],
         destination: "item",
-        dest_item: form.c[6]
-      )
+        dest_item: form.c[6])
     end
 
     let(:sr2) do # Root to group (not questioning)
       build_skip_rule(form.c[0],
         destination: "item",
-        dest_item: form.c[3] # This is a QingGroup
-      )
+        dest_item: form.c[3]) # This is a QingGroup
     end
 
     let(:sr3) do # Root to sub (this is a second SkipRule for form.c[1])
       build_skip_rule(form.c[1],
         destination: "item",
-        dest_item: form.c[3].c[1]
-      )
+        dest_item: form.c[3].c[1])
     end
 
     let(:sr4) do # Sub to same sub
       build_skip_rule(form.c[3].c[0],
         destination: "item",
-        dest_item: form.c[3].c[2]
-      )
+        dest_item: form.c[3].c[2])
     end
 
     let(:sr5) do # Sub to different sub
       build_skip_rule(form.c[3].c[1],
         destination: "item",
-        dest_item: form.c[5].c[2].c[1]
-      )
+        dest_item: form.c[5].c[2].c[1])
     end
 
     let(:sr6) do # Sub to root
       build_skip_rule(form.c[3].c[2],
         destination: "item",
-        dest_item: form.c[6]
-      )
+        dest_item: form.c[6])
     end
 
     let(:sr7) do # Sub to end
       build_skip_rule(form.c[5].c[2].c[0],
-        destination: "end"
-      )
+        destination: "end")
     end
 
     before do
@@ -149,10 +142,14 @@ describe Forms::ConditionComputer do
     if empty
       expect(group).to be_empty
     else
-      expect(group.true_if).to eq "all_met"
-      expect(group.negate?).to be false
-      expect(group.members).to match_array(members)
+      expect_group_with_members(group, members)
     end
+  end
+
+  def expect_group_with_members(group, members)
+    expect(group.true_if).to eq "all_met"
+    expect(group.negate?).to be false
+    expect(group.members).to match_array(members)
   end
 
   def build_skip_rule(item, attribs)

--- a/spec/models/forms/condition_computer_spec.rb
+++ b/spec/models/forms/condition_computer_spec.rb
@@ -24,7 +24,7 @@ describe Forms::ConditionComputer do
         "integer",
         ["integer", "integer", "integer"],
         "integer",
-        ["integer", "integer", "integer"],
+        ["integer", "integer", ["integer", "integer"]],
         "integer"
       ])
     end
@@ -73,7 +73,7 @@ describe Forms::ConditionComputer do
     let(:sr5) do # Sub to different sub
       build_skip_rule(form.c[3].c[1],
         destination: "item",
-        dest_item: form.c[5].c[2]
+        dest_item: form.c[5].c[2].c[1]
       )
     end
 
@@ -85,7 +85,7 @@ describe Forms::ConditionComputer do
     end
 
     let(:sr7) do # Sub to end
-      build_skip_rule(form.c[5].c[1],
+      build_skip_rule(form.c[5].c[2].c[0],
         destination: "end"
       )
     end
@@ -119,7 +119,9 @@ describe Forms::ConditionComputer do
     # G6          SR1                 SR6
     #  Q6.1                       SR5
     #  Q6.2                       SR5
-    #  Q6.3                               SR7
+    #  G6.3
+    #   Q6.3.1                    SR5
+    #   Q6.3.2                            SR7
     # Q7                                  SR7
 
     it "returns correct ConditionGroups" do
@@ -135,7 +137,9 @@ describe Forms::ConditionComputer do
       expect_condition_group(form.c[5], members: [sr1grp, sr6grp])
       expect_condition_group(form.c[5].c[0], members: [sr5grp])
       expect_condition_group(form.c[5].c[1], members: [sr5grp])
-      expect_condition_group(form.c[5].c[2], members: [sr7grp])
+      expect_condition_group(form.c[5].c[2], empty: true)
+      expect_condition_group(form.c[5].c[2].c[0], members: [sr5grp])
+      expect_condition_group(form.c[5].c[2].c[1], members: [sr7grp])
       expect_condition_group(form.c[6], members: [sr7grp])
     end
   end

--- a/spec/requests/form_odk_rendering_spec.rb
+++ b/spec/requests/form_odk_rendering_spec.rb
@@ -122,8 +122,14 @@ describe "form rendering for odk",:odk, :reset_factory_sequences do
     let(:form) do
       create(:form, :published, :with_version,
         name: "Basic Group",
-        question_types: [["text", "text", "text"]]
+        question_types: ["text", ["text", "text", "text"]]
       )
+    end
+
+    before do
+      # Test conditions on groups.
+      form.c[1].display_conditions.create!(ref_qing: form.c[0], op: "eq", value: "foo")
+      form.c[1].update!(display_if: "all_met")
     end
 
     it "should render proper xml" do


### PR DESCRIPTION
Adds ConditionComputer and specs and supporting classes.

Also adds support for display conditions on groups for ODK form rendering. This was a cleaner way to apply skip rules (skip the whole group with one computed condition instead of adding computed conditions to every single member of the group). It's also a nice feature that we really should have separate from this. I also created issues for adding condition capability to groups in other areas (e.g. web responses, form builder).