### PR TITLE
8064 2 questioning form logic updates

### DIFF
--- a/app/assets/javascripts/views/questioning_form_view.js.coffee
+++ b/app/assets/javascripts/views/questioning_form_view.js.coffee
@@ -17,7 +17,8 @@ class ELMO.Views.QuestioningFormView extends ELMO.Views.QuestionFormView
     @showField('read_only', @showReadOnly())
     @showField('required', @showRequired())
     @showField('hidden', @showHidden())
-    @showField('condition', @showCondition())
+    @showField('display_logic', @showDisplayLogic())
+    @showField('skip_logic', @showSkipLogic())
 
   showDefault: ->
     @defaultableTypes.indexOf(@fieldValue('qtype_name')) != -1
@@ -31,5 +32,8 @@ class ELMO.Views.QuestioningFormView extends ELMO.Views.QuestionFormView
   showHidden: ->
     @super.metadataTypeBlank.call(this)
 
-  showCondition: ->
+  showDisplayLogic: ->
+    @super.metadataTypeBlank.call(this)
+
+  showSkipLogic: ->
     @super.metadataTypeBlank.call(this)

--- a/spec/features/questionings_form_spec.rb
+++ b/spec/features/questionings_form_spec.rb
@@ -34,6 +34,16 @@ describe "questionings form", js: true  do
         expect_visible("display_logic", true)
         expect_visible("skip_logic", true)
       end
+
+      it "should display default only if question type is defaultable" do
+        visit(edit_questioning_path(qing, locale: "en", mode: "m", mission_name: get_mission.compact_name))
+        select "Select One", from: "questioning_question_attributes_qtype_name"
+        expect_editable("default", false)
+        select "Text", from: "Type" #text is defaultable
+        expect_editable("default", true)
+        select "Long Text", from: "Type"
+        expect_editable("default", false)
+      end
     end
 
     context "when published" do

--- a/spec/features/questionings_form_spec.rb
+++ b/spec/features/questionings_form_spec.rb
@@ -44,6 +44,17 @@ describe "questionings form", js: true  do
         select "Long Text", from: "Type"
         expect_editable("default", false)
       end
+
+      it "should display readonly only if default is not empty" do
+        visit(edit_questioning_path(qing, locale: "en", mode: "m", mission_name: get_mission.compact_name))
+        select "Text", from: "Type" # Text is defaultable
+        expect_editable("read_only", false)
+        fill_in "Default Answer", with: "Test"
+        expect_editable("read_only", true)
+        fill_in "Default Answer", with: ""
+        page.execute_script '$("#questioning_default").trigger("keyup")'
+        expect_editable("read_only", false)
+      end
     end
 
     context "when published" do

--- a/spec/features/questionings_form_spec.rb
+++ b/spec/features/questionings_form_spec.rb
@@ -35,6 +35,20 @@ describe "questionings form", js: true  do
         expect_visible("skip_logic", true)
       end
 
+      it "should hide hidden option when metadata field has a value" do
+        visit(edit_questioning_path(qing, locale: "en", mode: "m", mission_name: get_mission.compact_name))
+        select "Select One", from: "questioning_question_attributes_qtype_name"
+        expect_visible("hidden", true)
+        select "Date/Time", from: "Type"
+        expect_visible("hidden", true)
+        select "Form Start Time", from: "Metadata Type"
+        expect_visible("hidden", false)
+        within(:css, ".question_metadata_type") do
+          select "", from: "Metadata Type"
+        end
+        expect_visible("hidden", true)
+      end
+
       it "should display default only if question type is defaultable" do
         visit(edit_questioning_path(qing, locale: "en", mode: "m", mission_name: get_mission.compact_name))
         select "Select One", from: "questioning_question_attributes_qtype_name"

--- a/spec/features/questionings_form_spec.rb
+++ b/spec/features/questionings_form_spec.rb
@@ -53,7 +53,7 @@ describe "questionings form", js: true  do
         visit(edit_questioning_path(qing, locale: "en", mode: "m", mission_name: get_mission.compact_name))
         select "Select One", from: "questioning_question_attributes_qtype_name"
         expect_editable("default", false)
-        select "Text", from: "Type" #text is defaultable
+        select "Text", from: "Type" # Text is defaultable
         expect_editable("default", true)
         select "Long Text", from: "Type"
         expect_editable("default", false)


### PR DESCRIPTION
Story says "Show required iff not readonly and metadata is blank." Problem: this is not a case because readonly is only available if a question type is defaultable, and only text questions are defaultable, and metadata is not available for text questions. 