### PR TITLE
7468: Loading / status icon wrapping fix

### DIFF
--- a/app/assets/javascripts/app.js
+++ b/app/assets/javascripts/app.js
@@ -85,11 +85,11 @@
       if (link.next('ul').is(':hidden')) link.dropdown('toggle');
 
       // show loading ind
-      link.next('ul').find('div.loading_indicator img').show();
+      link.next('ul').find('div.inline-load-ind img').show();
 
       link.next('ul').load(self.url_builder.build('forms') + '?dropdown=1', function() {
         // hide loading ind
-        link.next('ul').find('div.loading_indicator img').hide();
+        link.next('ul').find('div.inline-load-ind img').hide();
       });
 
     }

--- a/app/assets/javascripts/views/regenerable_field_view.js.coffee
+++ b/app/assets/javascripts/views/regenerable_field_view.js.coffee
@@ -12,7 +12,7 @@ class ELMO.Views.RegenerableFieldView extends ELMO.Views.ApplicationView
 
     container = target.closest('.regenerable-field')
     displayEl = container.find('span[data-value]')
-    loading_indicator = container.find('div.loading_indicator img')
+    inline_load_ind = container.find('div.inline-load-ind img')
     success_indicator = container.find('.success')
     error_indicator = container.find('.failure')
 
@@ -25,7 +25,7 @@ class ELMO.Views.RegenerableFieldView extends ELMO.Views.ApplicationView
     target.attr('disabled', 'disabled')
     success_indicator.hide()
     error_indicator.hide()
-    loading_indicator.show()
+    inline_load_ind.show()
 
     $.ajax
       method: 'post'
@@ -35,10 +35,10 @@ class ELMO.Views.RegenerableFieldView extends ELMO.Views.ApplicationView
           $(displayEl[0]).data(value: data.value)
           $(displayEl[0]).text(data.value)
           target.text(I18n.t('common.regenerate'))
-        loading_indicator.hide()
+        inline_load_ind.hide()
         success_indicator.show()
       error: ->
-        loading_indicator.hide()
+        inline_load_ind.hide()
         error_indicator.show()
       complete: ->
         target.removeAttr('disabled')

--- a/app/assets/stylesheets/all/components/_main.scss
+++ b/app/assets/stylesheets/all/components/_main.scss
@@ -224,6 +224,8 @@ div.regenerable-field {
 
   div.loading_indicator {
     margin-left: 0.5em;
+    width: 20px;
+    display: inline-block;
   }
 }
 

--- a/app/assets/stylesheets/all/components/_main.scss
+++ b/app/assets/stylesheets/all/components/_main.scss
@@ -138,7 +138,7 @@ table.index_table th, table.form th { text-align: $left; color: #444; background
     font-size: 90%; padding: 3px 10px 3px 3px; }
 
 
-div.loading_indicator {
+div.inline-load-ind {
   .success {
     color: $theme-green;
   }
@@ -147,16 +147,8 @@ div.loading_indicator {
     color: $theme-red;
   }
 
-  div.loading_indicator_inline {
-    width: 16px;
-    display: inline-block;
-    vertical-align: top;
-  }
-
-  div.loading_indicator_floating {
-    width: 16px;
-    float: $left;
-  }
+  width: 20px;
+  display: inline-block;
 }
 
 i.fa-certificate {
@@ -222,9 +214,8 @@ div.regenerable-field {
     margin-left: 2em;
   }
 
-  div.loading_indicator {
+  div.inline-load-ind {
     margin-left: 0.5em;
-    width: 20px;
     display: inline-block;
   }
 }

--- a/app/assets/stylesheets/all/components/_questions.scss
+++ b/app/assets/stylesheets/all/components/_questions.scss
@@ -107,17 +107,12 @@ form.questioning_form {
   z-index: 300 !important;
 }
 
-/* Special style for option set box to accommodate link and loading indicator */
+/* Special style for option set box to accommodate link */
 div.form-field.question_option_set_id {
 
   div.control div.widget select {
     width: 260px;
     display: inline-block;
-  }
-
-  div.loading_indicator {
-    margin-left: 5px;
-    vertical-align: middle;
   }
 }
 

--- a/app/assets/stylesheets/all/components/_sms_tests.scss
+++ b/app/assets/stylesheets/all/components/_sms_tests.scss
@@ -8,11 +8,6 @@
       height: 75px;
     }
 
-    .loading_indicator {
-      vertical-align: bottom;
-      margin-bottom: 6px;
-    }
-
     h2 {
       margin-top: 0;
     }

--- a/app/assets/stylesheets/screen/_screen.scss
+++ b/app/assets/stylesheets/screen/_screen.scss
@@ -68,15 +68,13 @@ body {
     }
   }
 
-  form#change_mission {
-    select {
-      font-size: 9pt;
-      vertical-align: top;
-      display: inline-block;
-      width: 190px;
-      height: 31px;
-      margin-right: 10px;
-    }
+  #change-mission {
+    font-size: 9pt;
+    vertical-align: top;
+    display: inline-block;
+    width: 190px;
+    height: 31px;
+    margin-right: 10px;
   }
 }
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -49,12 +49,11 @@ module ApplicationHelper
   end
 
   # renders a loading indicator image wrapped in a wrapper
-  def loading_indicator(options = {})
-    floating = options[:floating] ? "_floating" : "_inline"
-    content_tag("div", class: "loading_indicator loading_indicator#{floating}", id: options[:id]) do
+  def inline_load_ind(options = {})
+    content_tag("div", class: "inline-load-ind", id: options[:id]) do
       body = image_tag("load-ind-small#{options[:header] ? '-header' : ''}.gif",
         style: "display: none",
-        id: "loading_indicator" + (options[:id] ? "_#{options[:id]}" : ""))
+        id: "inline_load_ind" + (options[:id] ? "_#{options[:id]}" : ""))
 
       if options[:success_failure]
         body += content_tag("i", "", class: "success fa fa-fw fa-check-circle", style: "display: none")

--- a/app/helpers/elmo_form_builder.rb
+++ b/app/helpers/elmo_form_builder.rb
@@ -74,7 +74,7 @@ class ElmoFormBuilder < ActionView::Helpers::FormBuilder
           class: "regenerate btn btn-default btn-xs", data: data, type: "button")
 
         # Loading indicator
-        body += @template.loading_indicator(success_failure: true)
+        body += @template.inline_load_ind(success_failure: true)
 
         # Backbone view
         body += @template.content_tag(:script,

--- a/app/views/forms/_screen.html.erb
+++ b/app/views/forms/_screen.html.erb
@@ -18,7 +18,6 @@
       <%# This link should be last because it has loading ind after it. %>
       <%= link_to(icon_tag(:print) + t("form.print_form"), "#", class: "print-link",
         "data-form-id": @form.id) %>
-      <%= loading_indicator(id: @form.id) %>
     <% end %>
   <% end %>
 

--- a/app/views/layouts/_userinfo.html.erb
+++ b/app/views/layouts/_userinfo.html.erb
@@ -3,12 +3,15 @@
     <div class="mission-operations-container">
       <% unless admin_mode? %>
         <% if @accessible_missions.any? %>
-          <form id="change_mission">
+          <form>
             <%# Changing missions when on a post or put request doesn't make sense, so we disable with message in that case. %>
-            <%= select_tag('change_mission',
+            <%= select_tag("change_mission",
               options_from_collection_for_select(@accessible_missions, 'compact_name', 'name', current_mission.try(:compact_name)),
-              class: 'form-control', prompt: "[#{I18n.t('common.none')}]",
-              disabled: !request.get?, title: request.get? ? '' : I18n.t('layout.mission_change_get_only')) %>
+              id: "change-mission",
+              class: 'form-control',
+              prompt: "[#{I18n.t('common.none')}]",
+              disabled: !request.get?,
+              title: request.get? ? '' : I18n.t('layout.mission_change_get_only')) %>
           </form>
         <% end %>
       <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -29,7 +29,7 @@
       login_path: login_path
     )%>);
     ELMO.index_table_views = {}
-    new ELMO.Views.MissionChangeDropdown({el: '#change_mission select'});
+    new ELMO.Views.MissionChangeDropdown({el: 'select#change-mission'});
   <% end %>
 
   <%= yield(:per_page_js) %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -72,7 +72,7 @@
                   </a>
                   <%# empty until ajax call %>
                   <ul class="dropdown-menu" role="menu">
-                    <li><%= loading_indicator %></li>
+                    <li><%= inline_load_ind %></li>
                   </ul>
                 </li>
               <%# else mission is locked %>

--- a/app/views/reports/show.html.erb
+++ b/app/views/reports/show.html.erb
@@ -7,7 +7,6 @@
       <%= link_to(icon_tag(:export) + t("report/report.export_to_csv"),
         report_path(@report, :format => :csv), :class => 'export-link') %>
     <% end %>
-    <%= loading_indicator(:id => "report_load_ind") %>
   <% end %>
 </div>
 <div class="report_view">

--- a/spec/features/modes_flow_spec.rb
+++ b/spec/features/modes_flow_spec.rb
@@ -13,7 +13,7 @@ feature 'switching between missions and modes', js: true do
   scenario 'should work' do
     # We get logged in to mission2, so first test that changing to mission1 from mission2 root works.
     expect(current_url).to match("/m/#{@mission2.compact_name}")
-    select(@mission1.name, from: 'change_mission')
+    select(@mission1.name, from: 'change-mission')
     expect(page).to have_selector('#title h2', text: /#{@mission1.name}/i)
 
     # Smart redirect on mission change should work.
@@ -22,12 +22,12 @@ feature 'switching between missions and modes', js: true do
     click_link('Forms')
     click_link(@form.name)
     expect(page).to have_selector('h1.title', text: @form.name)
-    select(@mission2.name, from: 'change_mission')
+    select(@mission2.name, from: 'change-mission')
     expect(page).to have_selector('h1.title', text: 'Forms')
 
     # Changing mission from unauthorized page should work.
     visit('/en/unauthorized')
-    select(@mission1.name, from: 'change_mission')
+    select(@mission1.name, from: 'change-mission')
     sleep 2 # Test fails without this, even though have_selector is supposed to wait.
     expect(page).to have_selector('#title h2', text: /#{@mission1.name}/i)
   end

--- a/spec/requests/admin_mode_spec.rb
+++ b/spec/requests/admin_mode_spec.rb
@@ -56,10 +56,10 @@ describe 'AdminMode' do
 
   it "mission dropdown should not be visible in admin mode" do
     login(@admin)
-    assert_select('form#change_mission')
+    assert_select('select#change-mission')
     get_s('/en/admin')
 
-    assert_select('form#change_mission', false)
+    assert_select('select#change-mission', false)
 
     # exit admin mode link should be visible instead
     assert_select('a.exit-admin-mode')


### PR DESCRIPTION
Trivial CSS change to fix wrapping for small loading / status icons on regenerate buttons.